### PR TITLE
🧹 remove leftover console.log in Article.vue

### DIFF
--- a/frontend/src/components/Article.vue
+++ b/frontend/src/components/Article.vue
@@ -25,8 +25,6 @@ onMounted(async () => {
   document.querySelectorAll('pre code').forEach((block) => {
     hljs.highlightElement(block as HTMLElement)
   })
-
-  console.log(markdownContent.value)
 })
 </script>
 


### PR DESCRIPTION
### 🎯 What:
Removed a leftover `console.log(markdownContent.value)` from `frontend/src/components/Article.vue`.

### 💡 Why:
Debugging console logs should be removed to maintain a clean browser console output and improve code maintainability.

### ✅ Verification:
- Manually inspected the file to confirm the line was removed.
- Verified that the Vue component still bundles correctly using `bun build`.

### ✨ Result:
Cleaner code in `Article.vue` without unnecessary logging.

---
*PR created automatically by Jules for task [12292526055950733458](https://jules.google.com/task/12292526055950733458) started by @gregyjames*