### PR TITLE
Fix hardcoded backend ports in API and database storage

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -66,13 +66,15 @@ func main(){
 	}
 	
 	db.AutoMigrate(&Article{})
-	
-	app.Get("/", func(c *fiber.Ctx) error {
+
+	api := app.Group("/api")
+
+	api.Get("/", func(c *fiber.Ctx) error {
 		//return c.SendString("Hello, World!")
 		return c.JSON(fiber.Map{"message": "Hello from Go!"})
 	})
 
-	app.Delete("/delete/:id", func(c *fiber.Ctx) error {
+	api.Delete("/delete/:id", func(c *fiber.Ctx) error {
 		id := c.Params("id")
 
 		if err := db.Delete(&Article{}, id).Error; err != nil {
@@ -102,7 +104,7 @@ func main(){
 		})
 
 
-	app.Get("/getarticles", func(c *fiber.Ctx) error {
+	api.Get("/getarticles", func(c *fiber.Ctx) error {
 		var articles []Article
 		if err := db.Find(&articles).Error; err != nil {
 			return c.Status(500).JSON(fiber.Map{
@@ -112,7 +114,7 @@ func main(){
 		return c.JSON(articles)
 	})
 
-	app.Post("/add", func(c *fiber.Ctx) error {
+	api.Post("/add", func(c *fiber.Ctx) error {
 	var body RequestBody
 
 	if err := json.Unmarshal(c.Body(), &body); err != nil {
@@ -170,7 +172,7 @@ func main(){
 		out.Close()
 
 		// Step 3: Replace image URLs in Markdown
-		markdownContent = strings.ReplaceAll(markdownContent, imgURL, fmt.Sprintf("http://localhost:3000/images/%d/", filenameID)+filename)
+		markdownContent = strings.ReplaceAll(markdownContent, imgURL, fmt.Sprintf("/images/%d/", filenameID)+filename)
 	}
 	
 	if err != nil {
@@ -242,7 +244,7 @@ func downloadImage(url string, dirname int64) string {
 	defer out.Close()
 
 	io.Copy(out, resp.Body)
-	return fmt.Sprintf("http://localhost:3000/images/%d/", dirname) + name
+	return fmt.Sprintf("/images/%d/", dirname) + name
 }
 
 func extractImageSources(n *html.Node) []string {

--- a/frontend/server.go
+++ b/frontend/server.go
@@ -3,8 +3,11 @@ package main
 import (
 	"log"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func main() {
@@ -18,6 +21,18 @@ func main() {
 		distDir = "dist"
 	}
 
+	backendURLStr := os.Getenv("BACKEND_URL")
+	if backendURLStr == "" {
+		backendURLStr = "http://backend:3000"
+	}
+
+	backendURL, err := url.Parse(backendURLStr)
+	if err != nil {
+		log.Fatalf("Invalid backend URL: %v", err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+
 	// Create file system from dist directory
 	fileSystem := http.Dir(distDir)
 	fileServer := http.FileServer(fileSystem)
@@ -25,6 +40,12 @@ func main() {
 	// Custom handler for SPA routing
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
+
+		// Forward requests to backend APIs and assets
+		if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/images/") || strings.HasPrefix(path, "/articles/") {
+			proxy.ServeHTTP(w, r)
+			return
+		}
 
 		// Check if file exists
 		fullPath := filepath.Join(distDir, path)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,7 +20,7 @@ const isSubmitting = ref(false)
 const submitForm = async () => {
   isSubmitting.value = true
   try{
-    await fetch('http://localhost:3000/add', {
+    await fetch('/api/add', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ 

--- a/frontend/src/components/Article.vue
+++ b/frontend/src/components/Article.vue
@@ -10,7 +10,7 @@ const route = useRoute()
 
 onMounted(async () => {
   const articleID = route.params.id
-  const articleURL = `http://localhost:3000/articles/${articleID}`
+  const articleURL = `/articles/${articleID}`
 
   const res = await fetch(articleURL)
   const raw = await res.text()

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -23,7 +23,7 @@ const viewMode = ref<'card' | 'list'>('card')
 const selectedTag = ref<string | null>(null)
 
 const fetchArticles = async () => {
-  const res = await axios.get('http://127.0.0.1:3000/getarticles')
+  const res = await axios.get('/api/getarticles')
   articles.value = res.data
 }
 
@@ -52,7 +52,7 @@ const deleteArticle = async (id: number) => {
   if (!confirm("Are you sure you want to delete this article?")) return
 
   try {
-    await axios.delete(`http://127.0.0.1:3000/delete/${id}`)
+    await axios.delete(`/api/delete/${id}`)
     articles.value = articles.value.filter(article => article.ID !== id)
   } catch (err) {
     console.error('Failed to delete article', err)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,5 +14,12 @@ export default defineConfig({
     alias: {
       crypto: 'crypto-browserify',
     },
+  },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+      '/images': 'http://localhost:3000',
+      '/articles': 'http://localhost:3000'
+    }
   }
 })


### PR DESCRIPTION
This PR removes hardcoded `http://localhost:3000` port configurations from the frontend and backend, enabling users to run the backend on different ports without breaking article image generation and frontend API requests.

It implements a unified API structure using an `/api` prefix on the backend routes and configures relative paths for asset loading (e.g. `/images/...` and `/articles/...`). Both the Vite development server and the Go production server were updated to proxy these routes to the backend correctly.

This satisfies the task requirement to confirm the existing behavior and eliminate the hardcoded connection values. No database migration for old articles is performed as per the instructions.

---
*PR created automatically by Jules for task [12239560689400075123](https://jules.google.com/task/12239560689400075123) started by @gregyjames*