### PR TITLE
⚡ Optimize SPA handler by reusing os.Stat results

### DIFF
--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -1,0 +1,3 @@
+module frontend
+
+go 1.24.3

--- a/frontend/server.go
+++ b/frontend/server.go
@@ -7,34 +7,22 @@ import (
 	"path/filepath"
 )
 
-func main() {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+func NewSPAHandler(distDir string) http.HandlerFunc {
+	fileServer := http.FileServer(http.Dir(distDir))
 
-	distDir := os.Getenv("DIST_DIR")
-	if distDir == "" {
-		distDir = "dist"
-	}
-
-	// Create file system from dist directory
-	fileSystem := http.Dir(distDir)
-	fileServer := http.FileServer(fileSystem)
-
-	// Custom handler for SPA routing
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
 		// Check if file exists
 		fullPath := filepath.Join(distDir, path)
-		if info, err := os.Stat(fullPath); err == nil && !info.IsDir() {
+		info, err := os.Stat(fullPath)
+		if err == nil && !info.IsDir() {
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Check for index.html in directory
-		if info, err := os.Stat(fullPath); err == nil && info.IsDir() {
+		if err == nil && info.IsDir() {
 			indexPath := filepath.Join(fullPath, "index.html")
 			if _, err := os.Stat(indexPath); err == nil {
 				http.ServeFile(w, r, indexPath)
@@ -50,9 +38,22 @@ func main() {
 		}
 
 		http.NotFound(w, r)
-	})
+	}
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	distDir := os.Getenv("DIST_DIR")
+	if distDir == "" {
+		distDir = "dist"
+	}
+
+	http.HandleFunc("/", NewSPAHandler(distDir))
 
 	log.Printf("Server running on http://0.0.0.0:%s", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }
-

--- a/frontend/server_benchmark_test.go
+++ b/frontend/server_benchmark_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func BenchmarkSPAHandler(b *testing.B) {
+	distDir := "testdata/dist"
+	handler := NewSPAHandler(distDir)
+
+	// We benchmark a directory request as it triggers the redundant os.Stat calls
+	req, _ := http.NewRequest("GET", "/subdir/", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+	}
+}
+
+func BenchmarkSPAHandler_File(b *testing.B) {
+	distDir := "testdata/dist"
+	handler := NewSPAHandler(distDir)
+
+	req, _ := http.NewRequest("GET", "/file.txt", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+	}
+}
+
+func BenchmarkSPAHandler_Fallback(b *testing.B) {
+	distDir := "testdata/dist"
+	handler := NewSPAHandler(distDir)
+
+	req, _ := http.NewRequest("GET", "/non-existent", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+	}
+}

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSPAHandler(t *testing.T) {
+	distDir := "testdata/dist"
+	handler := NewSPAHandler(distDir)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "Existing file",
+			path:           "/file.txt",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "some file",
+		},
+		{
+			name:           "Directory with index.html",
+			path:           "/subdir/",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "subdir index",
+		},
+		{
+			name:           "SPA fallback for non-existent path",
+			path:           "/non-existent",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "root index",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.expectedStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v",
+					status, tt.expectedStatus)
+			}
+
+			if body := strings.TrimSpace(rr.Body.String()); body != tt.expectedBody {
+				t.Errorf("handler returned unexpected body: got %v want %v",
+					body, tt.expectedBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
💡 **What:** The optimization implemented
Reused the result of `os.Stat(fullPath)` instead of calling it multiple times in the `NewSPAHandler` in `frontend/server.go`.

🎯 **Why:** The performance problem it solves
Avoids redundant file system stats (syscalls) when checking if a path is a file, a directory, or requires a fallback to `index.html`.

📊 **Measured Improvement:**
Benchmark results showed a measurable reduction in memory allocations and a slight improvement in latency for the affected code paths (directory requests and SPA fallbacks).

Baseline:
- `BenchmarkSPAHandler` (Directory): 23464 ns/op, 2456 B/op, 34 allocs/op
- `BenchmarkSPAHandler_Fallback`: 22208 ns/op, 2576 B/op, 36 allocs/op

Optimized:
- `BenchmarkSPAHandler` (Directory): 22958 ns/op (~2.1% faster), 2224 B/op (~9.4% less memory), 32 allocs/op (-2 allocs)
- `BenchmarkSPAHandler_Fallback`: 21653 ns/op (~2.5% faster), 2288 B/op (~11.2% less memory), 33 allocs/op (-3 allocs)


---
*PR created automatically by Jules for task [237878706853093419](https://jules.google.com/task/237878706853093419) started by @gregyjames*