### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/gregyjames/readr/security/code-scanning/1](https://github.com/gregyjames/readr/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.  
Best fix here: add:

```yml
permissions:
  contents: read
```

directly under the `on:` block (before `concurrency:` is a clean placement). This preserves existing behavior while explicitly restricting token scope to what checkout/build/test workflows typically require.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
