### PR TITLE
fix(search): prevent XSS by returning result tags as data, not HTML

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -180,6 +180,23 @@ func initDB() *gorm.DB {
 	return db
 }
 
+func splitTags(raw string) []string {
+	tags := make([]string, 0)
+	if raw == "" {
+		return tags
+	}
+	seen := make(map[string]bool)
+	for _, rawTag := range strings.Split(raw, ",") {
+		tag := strings.ToLower(strings.TrimSpace(rawTag))
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		tags = append(tags, tag)
+	}
+	return tags
+}
+
 func syncArticleToFTS(db *gorm.DB, id int64, title string, tags string) {
 	db.Exec("DELETE FROM articles_fts WHERE rowid = ?", id)
 	err := db.Exec("INSERT INTO articles_fts(rowid, title, content) VALUES (?, ?, ?)", id, title, tags).Error
@@ -598,12 +615,11 @@ func setupApp(customDB ...*gorm.DB) *fiber.App {
 		}
 		
 		type SearchResult struct {
-			ID      int64  `json:"id"`
-			Title   string `json:"title"`
-			Excerpt string `json:"excerpt"`
+			ID    int64    `json:"id"`
+			Title string   `json:"title"`
+			Tags  []string `json:"tags"`
 		}
 		
-		var results []SearchResult
 		// Format query for prefix matching (e.g. "pay" -> "pay*")
 		cleanQuery := strings.ReplaceAll(query, "\"", "")
 		cleanQuery = strings.ReplaceAll(cleanQuery, "'", "")
@@ -615,19 +631,32 @@ func setupApp(customDB ...*gorm.DB) *fiber.App {
 		}
 		safeQuery := strings.Join(parts, " AND ")
 		
+		var rows []struct {
+			ID    int64
+			Title string
+			Tags  string
+		}
 		err := db.Raw(`
-			SELECT rowid as id, title, snippet(articles_fts, 1, '<mark>', '</mark>', '...', 25) as excerpt
+			SELECT rowid as id, title, content as tags
 			FROM articles_fts
 			WHERE articles_fts MATCH ?
 			ORDER BY rank
 			LIMIT 15
-		`, safeQuery).Scan(&results).Error
+		`, safeQuery).Scan(&rows).Error
 		
 		if err != nil {
 			logger.Error("FTS search failed", zap.Error(err))
 			return c.Status(500).JSON(fiber.Map{"error": "Search failed"})
 		}
 		
+		results := make([]SearchResult, 0, len(rows))
+		for _, row := range rows {
+			results = append(results, SearchResult{
+				ID:    row.ID,
+				Title: row.Title,
+				Tags:  splitTags(row.Tags),
+			})
+		}
 		return c.JSON(results)
 	})
 

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -879,7 +880,130 @@ func TestStaticAndSPAFallback(t *testing.T) {
 	}
 }
 
+// setupApp does not create the FTS table, only initDB does, so search tests make their own.
+func initSearchTestDB(t *testing.T, articles ...Article) *gorm.DB {
+	t.Helper()
+	db := initTestDB()
+	db.Exec("DELETE FROM articles")
+	db.Exec(`CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
+		title,
+		content,
+		tokenize='porter'
+	)`)
+	db.Exec("DELETE FROM articles_fts")
 
+	for _, article := range articles {
+		if err := db.Create(&article).Error; err != nil {
+			t.Fatalf("Failed to seed article %d: %v", article.ID, err)
+		}
+		syncArticleToFTS(db, article.ID, article.Title, article.Tags)
+	}
+	return db
+}
 
+type searchResultJSON struct {
+	ID    int64    `json:"id"`
+	Title string   `json:"title"`
+	Tags  []string `json:"tags"`
+}
 
+func searchBody(t *testing.T, db *gorm.DB, query string) ([]byte, []searchResultJSON) {
+	t.Helper()
+	app := setupApp(db)
+	target := "/api/search?q=" + url.QueryEscape(query)
+	resp, err := app.Test(httptest.NewRequest("GET", target, nil))
+	if err != nil {
+		t.Fatalf("Failed to GET %s: %v", target, err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected 200 for %s, got %d", target, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+	var results []searchResultJSON
+	if err := json.Unmarshal(body, &results); err != nil {
+		t.Fatalf("Failed to decode %s: %v (body %s)", target, err, string(body))
+	}
+	return body, results
+}
 
+func TestSearch_ReturnsMarkupInTitlesAsData(t *testing.T) {
+	const payload = `Payload <img src=x onerror="alert(1)">`
+	db := initSearchTestDB(t, Article{ID: 90, Title: payload, Tags: "security, <b>bold</b>"})
+
+	// Query a tag rather than the title, so any server-side snippet highlighting would fire.
+	body, results := searchBody(t, db, "security")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Title != payload {
+		t.Errorf("expected title %q, got %q", payload, results[0].Title)
+	}
+
+	if len(results[0].Tags) != 2 || results[0].Tags[1] != "<b>bold</b>" {
+		t.Errorf("expected tags [security <b>bold</b>], got %v", results[0].Tags)
+	}
+
+	// encoding/json escapes angle brackets, so check both forms. That escaping is not the
+	// protection here: JSON.parse restores it before the client renders.
+	for _, fragment := range []string{"<mark", `\u003cmark`} {
+		if strings.Contains(string(body), fragment) {
+			t.Errorf("expected no %s in response, got %s", fragment, string(body))
+		}
+	}
+}
+
+func TestSearch_ReturnsTagsArrayNotExcerpt(t *testing.T) {
+	db := initSearchTestDB(t, Article{ID: 91, Title: "Tagged Article", Tags: "security, tooling"})
+
+	body, results := searchBody(t, db, "Tagged")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	var raw []map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if _, ok := raw[0]["excerpt"]; ok {
+		t.Errorf("expected no excerpt field, got %s", string(body))
+	}
+	if _, ok := raw[0]["tags"]; !ok {
+		t.Errorf("expected a tags field, got %s", string(body))
+	}
+}
+
+func TestSearch_NormalizesTags(t *testing.T) {
+	db := initSearchTestDB(t, Article{ID: 92, Title: "Mixed Case", Tags: "AI, ai, Ai, Tech, tech "})
+
+	_, results := searchBody(t, db, "Mixed")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	want := []string{"ai", "tech"}
+	if len(results[0].Tags) != len(want) {
+		t.Fatalf("expected tags %v, got %v", want, results[0].Tags)
+	}
+	for i := range want {
+		if results[0].Tags[i] != want[i] {
+			t.Fatalf("expected tags %v, got %v", want, results[0].Tags)
+		}
+	}
+}
+
+func TestSearch_ArticleWithoutTagsReturnsEmptyArray(t *testing.T) {
+	db := initSearchTestDB(t, Article{ID: 93, Title: "Untagged Piece", Tags: ""})
+
+	body, results := searchBody(t, db, "Untagged")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Tags == nil {
+		t.Errorf("expected an empty tag array, got nil")
+	}
+	if strings.Contains(string(body), `"tags":null`) {
+		t.Errorf("expected \"tags\":[], got %s", string(body))
+	}
+}

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -56,10 +56,20 @@
               <span v-if="selectedIndex === index" class="text-xs text-gray-400 shrink-0 font-mono">↵ to jump</span>
             </div>
             
-            <p 
-              class="text-sm text-gray-500 dark:text-gray-400 line-clamp-2 leading-relaxed ml-7 search-excerpt"
-              v-html="result.excerpt"
-            ></p>
+            <div v-if="result.tags.length" class="flex flex-wrap gap-2 ml-7">
+              <span
+                v-for="tag in result.tags"
+                :key="tag"
+                :class="[
+                  'text-[10px] font-bold px-3 py-1.5 rounded-full uppercase tracking-widest transition-colors',
+                  isMatchedTag(tag)
+                    ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+                    : 'bg-gray-100/80 dark:bg-white/5 text-gray-700 dark:text-gray-300'
+                ]"
+              >
+                {{ tag }}
+              </span>
+            </div>
           </button>
         </div>
         
@@ -81,7 +91,7 @@ import emitter from '../event-bus'
 interface SearchResult {
   id: number
   title: string
-  excerpt: string
+  tags: string[]
 }
 
 const router = useRouter()
@@ -132,6 +142,11 @@ const close = () => {
   isOpen.value = false
 }
 
+const isMatchedTag = (tag: string) => {
+  const terms = query.value.toLowerCase().split(/\s+/).filter(Boolean)
+  return terms.some(term => tag.startsWith(term))
+}
+
 const selectNext = () => {
   if (selectedIndex.value < results.value.length - 1) {
     selectedIndex.value++
@@ -173,17 +188,3 @@ watchDebounced(query, async (newQuery) => {
   }
 }, { debounce: 300 })
 </script>
-
-<style>
-.search-excerpt mark {
-  background-color: rgba(16, 185, 129, 0.2); /* Emerald 500 w/ opacity */
-  color: inherit;
-  border-radius: 2px;
-  padding: 0 2px;
-  font-weight: 600;
-}
-.dark .search-excerpt mark {
-  background-color: rgba(16, 185, 129, 0.25);
-  color: #fff;
-}
-</style>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now display article tags instead of text excerpts.
  * Tags are shown in a consistent, lowercase, duplicate-free format.
  * Matching tags are highlighted when they correspond to the search query.
* **Improvements**
  * Search responses now provide tags as a structured list.
  * Results with no tags are handled cleanly.
  * Search result titles continue to preserve matching-term formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->