### PR TITLE
fix(ui): handle millisecond unix timestamps in list view date formatting

### DIFF
--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -58,7 +58,8 @@ function initReveal() {
 function formatDate(unixTs: number): string {
   // IDs under ~1e9 are likely DB sequential IDs, not timestamps — fall back gracefully
   if (unixTs < 1_000_000_000) return ''
-  const d = new Date(unixTs * 1000)
+  const ms = unixTs < 100_000_000_000 ? unixTs * 1000 : unixTs
+  const d = new Date(ms)
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 


### PR DESCRIPTION
  ## Summary
  
  Fixes a date formatting bug in the article list view where article IDs generated as Unix millisecond timestamps were incorrectly multiplied by 1000, causing dates to    
  render ~56,000 years in the future (e.g. MAR 22, 58632).
  ──────
  ##  Root Cause
  
  • Article IDs in the backend ingester are generated using time.Now().UnixMilli() (13 digits, ~1.78e12).
  • In Home.vue, formatDate() previously assumed all timestamps were in seconds and performed new Date(unixTs * 1000).
  • This multiplied millisecond timestamps by 1,000, resulting in timestamps ~1.78e15 ms and projecting dates into year 58632.
  ──────
  ##  Changes
  
  • Updated formatDate() in Home.vue:
      • Checks timestamp magnitude:
          • If unixTs < 100_000_000_000 (10-digit second timestamp from legacy records), converts to milliseconds via unixTs * 1000.
          • If unixTs >= 100_000_000_000 (13-digit millisecond timestamp), passes unixTs directly to new Date(ms).
  

  ──────
  ## 🧪 Verification
  
  [✓] Verified correct date formatting for current millisecond article IDs.
  [✓] Verified backwards compatibility for legacy second-based IDs.
  [✓] Production build passes cleanly (vite build).