### PR TITLE
Resilient http client

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -36,6 +36,10 @@ github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFe
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/backend/internal/agents/pipeline.go
+++ b/backend/internal/agents/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"example.com/backend/internal/repository"
+	"github.com/hashicorp/go-retryablehttp"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -118,17 +119,29 @@ func (p *AgentPool) processPipelineWithURL(job Job, apiURL string) {
 		return
 	}
 
-	client := &http.Client{
-		Timeout: 60 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			if len(via) > 0 {
-				req.Header.Set("Authorization", via[0].Header.Get("Authorization"))
-			}
-			return nil
-		},
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 3
+	retryClient.RetryWaitMin = 1 * time.Second
+	retryClient.RetryWaitMax = 10 * time.Second
+	retryClient.Logger = nil // suppress stdout default logging; logged via zap
+	retryClient.HTTPClient.Timeout = 60 * time.Second
+	retryClient.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if len(via) > 0 {
+			req.Header.Set("Authorization", via[0].Header.Get("Authorization"))
+		}
+		return nil
+	}
+	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if err != nil {
+			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		}
+		if resp != nil && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode >= 500) {
+			return true, nil
+		}
+		return false, nil
 	}
 
 	startTime := time.Now()
@@ -137,37 +150,31 @@ func (p *AgentPool) processPipelineWithURL(job Job, apiURL string) {
 		zap.String("model", model),
 	)
 
-	var resp *http.Response
-	for attempt := 0; attempt < 2; attempt++ {
-		req, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(bodyJSON))
-		if err != nil {
-			p.logger.Error("Pipeline failed to create HTTP request", zap.Error(err))
-			return
-		}
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("HTTP-Referer", "https://github.com/gregyjames/readr")
-		req.Header.Set("X-Title", "Readr Pipeline Agent")
-
-		resp, err = client.Do(req)
-		if err != nil {
-			p.logger.Error("Pipeline LLM request failed", zap.Error(err))
-			return
-		}
-
-		if resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests {
-			resp.Body.Close()
-			time.Sleep(3 * time.Second)
-			continue
-		}
-		break
+	req, err := retryablehttp.NewRequestWithContext(context.Background(), http.MethodPost, apiURL, bytes.NewReader(bodyJSON))
+	if err != nil {
+		p.logger.Error("Pipeline failed to create HTTP request", zap.Error(err))
+		return
 	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HTTP-Referer", "https://github.com/gregyjames/readr")
+	req.Header.Set("X-Title", "Readr Pipeline Agent")
 
+	resp, err := retryClient.Do(req)
+	if err != nil {
+		p.logger.Error("Pipeline LLM request failed", zap.Error(err), zap.Int64("article_id", job.ArticleID))
+		return
+	}
 	defer resp.Body.Close()
 
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		p.logger.Error("Pipeline failed to read LLM response body", zap.Error(err), zap.Int64("article_id", job.ArticleID))
+		return
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		p.logger.Error("Pipeline LLM request returned non-200 status", zap.Int("status", resp.StatusCode), zap.String("body", string(bodyBytes)))
+		p.logger.Error("Pipeline LLM request returned non-200 status", zap.Int("status", resp.StatusCode), zap.String("body", string(respBytes)), zap.Int64("article_id", job.ArticleID))
 		return
 	}
 
@@ -179,24 +186,42 @@ func (p *AgentPool) processPipelineWithURL(job Job, apiURL string) {
 	var llmResp struct {
 		Choices []struct {
 			Message struct {
-				Content string `json:"content"`
+				Content interface{} `json:"content"`
 			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
 		} `json:"choices"`
+		Error *struct {
+			Message string      `json:"message"`
+			Code    interface{} `json:"code"`
+		} `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil || len(llmResp.Choices) == 0 {
-		p.logger.Error("Pipeline failed to parse LLM response")
+
+	if err := json.Unmarshal(respBytes, &llmResp); err != nil {
+		p.logger.Error("Pipeline failed to parse LLM response JSON", zap.Error(err), zap.String("raw_response", string(respBytes)), zap.Int64("article_id", job.ArticleID))
 		return
 	}
 
-	rawJSON := strings.TrimSpace(llmResp.Choices[0].Message.Content)
-	if strings.HasPrefix(rawJSON, "```json") {
-		rawJSON = strings.TrimPrefix(rawJSON, "```json")
-		rawJSON = strings.TrimSuffix(rawJSON, "```")
+	if llmResp.Error != nil {
+		p.logger.Error("Pipeline received API error from LLM provider", zap.String("error_message", llmResp.Error.Message), zap.String("raw_response", string(respBytes)), zap.Int64("article_id", job.ArticleID))
+		return
+	}
+
+	if len(llmResp.Choices) == 0 {
+		p.logger.Error("Pipeline LLM response contained no choices", zap.String("raw_response", string(respBytes)), zap.Int64("article_id", job.ArticleID))
+		return
+	}
+
+	rawJSON := extractMessageContent(llmResp.Choices[0].Message.Content)
+	rawJSON = cleanJSONBlock(rawJSON)
+
+	if rawJSON == "" {
+		p.logger.Error("Pipeline LLM response message content was empty", zap.String("finish_reason", llmResp.Choices[0].FinishReason), zap.String("raw_response", string(respBytes)), zap.Int64("article_id", job.ArticleID))
+		return
 	}
 
 	var pipelineResp UnifiedPipelineResponse
 	if err := json.Unmarshal([]byte(rawJSON), &pipelineResp); err != nil {
-		p.logger.Error("Pipeline failed to unmarshal JSON into UnifiedPipelineResponse", zap.Error(err), zap.String("raw", rawJSON))
+		p.logger.Error("Pipeline failed to unmarshal JSON into UnifiedPipelineResponse", zap.Error(err), zap.String("raw", rawJSON), zap.String("raw_response", string(respBytes)), zap.Int64("article_id", job.ArticleID))
 		return
 	}
 

--- a/backend/internal/chat/service.go
+++ b/backend/internal/chat/service.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type ArticleFetcher interface {
@@ -21,16 +23,32 @@ type ArticleFetcher interface {
 type Service struct {
 	repo          *FileRepository
 	fetcher       ArticleFetcher
-	client        *http.Client
+	client        *retryablehttp.Client
 	openRouterURL string
 	defaultModel  string
 }
 
 func NewService(repo *FileRepository, fetcher ArticleFetcher) *Service {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 2
+	client.RetryWaitMin = 500 * time.Millisecond
+	client.RetryWaitMax = 3 * time.Second
+	client.Logger = nil
+	client.HTTPClient.Timeout = 120 * time.Second
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if err != nil {
+			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		}
+		if resp != nil && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) {
+			return true, nil
+		}
+		return false, nil
+	}
+
 	return &Service{
 		repo:          repo,
 		fetcher:       fetcher,
-		client:        &http.Client{Timeout: 120 * time.Second},
+		client:        client,
 		openRouterURL: "https://openrouter.ai/api/v1/chat/completions",
 		defaultModel:  "openai/gpt-3.5-turbo",
 	}
@@ -42,7 +60,9 @@ func (s *Service) SetOpenRouterURL(url string) {
 }
 
 func (s *Service) SetHTTPClient(client *http.Client) {
-	s.client = client
+	if client != nil {
+		s.client.HTTPClient = client
+	}
 }
 
 type openRouterRequest struct {
@@ -52,7 +72,7 @@ type openRouterRequest struct {
 }
 
 func (s *Service) FetchModels(ctx context.Context, apiKey string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openrouter.ai/api/v1/models", nil)
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, "https://openrouter.ai/api/v1/models", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +194,7 @@ func (s *Service) StreamMessage(ctx context.Context, sessionID string, apiKey st
 		return fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.openRouterURL, bytes.NewReader(bodyBytes))
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodPost, s.openRouterURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/backend/internal/ingest/fetcher.go
+++ b/backend/internal/ingest/fetcher.go
@@ -6,25 +6,31 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type HTTPFetcher struct {
-	client *http.Client
+	client *retryablehttp.Client
 }
 
 func NewHTTPFetcher(timeout time.Duration) *HTTPFetcher {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
+	client := retryablehttp.NewClient()
+	client.RetryMax = 2
+	client.RetryWaitMin = 500 * time.Millisecond
+	client.RetryWaitMax = 3 * time.Second
+	client.Logger = nil
+	client.HTTPClient.Timeout = timeout
 	return &HTTPFetcher{
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client: client,
 	}
 }
 
 func (f *HTTPFetcher) fetch(ctx context.Context, url string, userAgent string, errMsg string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create %s request failed: %w", errMsg, err)
 	}

--- a/backend/internal/ingest/summarizer.go
+++ b/backend/internal/ingest/summarizer.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type Summarizer interface {
@@ -15,13 +17,28 @@ type Summarizer interface {
 }
 
 type OpenRouterSummarizer struct {
-	client  *http.Client
+	client  *retryablehttp.Client
 	baseURL string
 }
 
 func NewOpenRouterSummarizer() *OpenRouterSummarizer {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 2
+	client.RetryWaitMin = 500 * time.Millisecond
+	client.RetryWaitMax = 3 * time.Second
+	client.Logger = nil
+	client.HTTPClient.Timeout = 15 * time.Second
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if err != nil {
+			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		}
+		if resp != nil && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) {
+			return true, nil
+		}
+		return false, nil
+	}
 	return &OpenRouterSummarizer{
-		client:  &http.Client{Timeout: 10 * time.Second},
+		client:  client,
 		baseURL: "https://openrouter.ai/api/v1/chat/completions",
 	}
 }
@@ -59,7 +76,7 @@ func (s *OpenRouterSummarizer) Summarize(ctx context.Context, title, body, apiKe
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL, bytes.NewReader(bodyBytes))
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodPost, s.baseURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary of Changes
  
  ### Overview
  Integrated github.com/hashicorp/go-retryablehttp across the backend to standardize resilient HTTP execution for LLM completions, web article ingestion, and image downloading.

  ### Key Improvements
  
  1. Dependency Addition (build(deps)):
      • Added github.com/hashicorp/go-retryablehttp (and go-cleanhttp) for drop-in HTTP client resilience with exponential backoff and randomized jitter.
  2. Unified Agent Pipeline (internal/agents/pipeline.go):
      • Replaced manual request retry loop with retryablehttp.Client.
      • Configured custom retry policy to automatically retry on 429 (Too Many Requests), 402 (Payment/Quota), 5xx (Server Errors), and transient connection resets while  
      buffering and preserving request bodies across attempts.
      • Suppressed raw stdout logging in favor of structured zap logger outputs.
  3. Article Ingestion & Summarizer (internal/ingest/fetcher.go, internal/ingest/summarizer.go):
      • Upgraded HTTPFetcher to retry transient network drops and server errors when fetching remote HTML articles and images.
      • Upgraded OpenRouterSummarizer to handle temporary rate limits and server errors with backoff.
  4. Chat Service (internal/chat/service.go):
      • Upgraded FetchModels and StreamMessage to use retryablehttp.
      • Preserved SetHTTPClient compatibility for mock testing.
  
  ──────
  ### Commit Breakdown
  
  • df9411c — build(deps): add github.com/hashicorp/go-retryablehttp dependency
  • d7a9891 — feat(agents): upgrade pipeline to use go-retryablehttp with exponential backoff and custom retry policy
  • 4a0d038 — feat(ingest): upgrade HTTPFetcher and OpenRouterSummarizer to use go-retryablehttp
  • 76309fc — feat(chat): upgrade chat service to use go-retryablehttp for model fetching and streaming completions
  ──────
  ### Verification
  
  • go test -v ./... executed cleanly across all backend packages with zero test regressions.