### PR TITLE
fix(security): sanitize untrusted HTML before every v-html sink

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -9,6 +9,7 @@
         "@vueuse/core": "^14.4.0",
         "axios": "^1.20.0",
         "crypto-browserify": "^3.12.1",
+        "dompurify": "^3.4.14",
         "highlight.js": "^11.12.0",
         "lucide-vue-next": "^1.0.0",
         "marked": "^18.0.11",
@@ -127,6 +128,8 @@
     "@types/hammerjs": ["@types/hammerjs@2.0.46", "", {}, "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw=="],
 
     "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
@@ -277,6 +280,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.14", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@vueuse/core": "^14.4.0",
     "axios": "^1.20.0",
     "crypto-browserify": "^3.12.1",
+    "dompurify": "^3.4.14",
     "highlight.js": "^11.12.0",
     "lucide-vue-next": "^1.0.0",
     "marked": "^18.0.11",

--- a/frontend/src/components/Article.vue
+++ b/frontend/src/components/Article.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onBeforeUnmount, watch, computed, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from 'axios'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import hljs from 'highlight.js'
 import 'highlight.js/styles/github-dark.css'
 import { Network } from 'vis-network'
@@ -507,10 +508,12 @@ const loadContent = async () => {
     // Strip YAML frontmatter (--- ... ---) so it never renders in the article view                                                                                 
     const strippedRaw = parsedRaw.replace(/^---[\s\S]*?---\n?/, '')  
 
-    markdownContent.value = await marked.parse(strippedRaw, {
+    // Sanitize before assignment: article bodies and wikilink-injected titles are
+    // untrusted, and marked passes raw HTML through.
+    markdownContent.value = DOMPurify.sanitize(await marked.parse(strippedRaw, {
       gfm: false,
       async: true
-    })
+    }))
 
     await nextTick()
     document.querySelectorAll('pre code').forEach((block) => {

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -76,6 +76,7 @@ import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useMagicKeys, watchDebounced } from '@vueuse/core'
 import axios from 'axios'
+import DOMPurify from 'dompurify'
 import emitter from '../event-bus'
 import { authState } from '../store/auth'
 
@@ -178,7 +179,11 @@ watchDebounced(query, async (newQuery) => {
   isLoading.value = true
   try {
     const res = await axios.get<SearchResult[]>(`/api/search?q=${encodeURIComponent(newQuery)}`)
-    results.value = res.data || []
+    // The excerpt is server-built HTML (FTS5 snippet); keep only the <mark> highlight.
+    results.value = (res.data || []).map(r => ({
+      ...r,
+      excerpt: DOMPurify.sanitize(r.excerpt ?? '', { ALLOWED_TAGS: ['mark'], ALLOWED_ATTR: [] })
+    }))
     selectedIndex.value = 0
   } catch (err) {
     console.error('Search failed:', err)

--- a/frontend/src/components/chat/ChatMessageItem.vue
+++ b/frontend/src/components/chat/ChatMessageItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, watch, nextTick } from 'vue'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import hljs from 'highlight.js'
 import 'highlight.js/styles/github-dark.css'
 import type { Message } from '../../types/chat'
@@ -23,9 +24,10 @@ const renderedContent = computed(() => {
   if (!props.message.content) return ''
   try {
     const html = marked.parse(props.message.content, { async: false })
-    return typeof html === 'string' ? html : ''
+    return typeof html === 'string' ? DOMPurify.sanitize(html) : ''
   } catch (err) {
-    return props.message.content
+    // Never fall back to the raw string: it reaches v-html.
+    return ''
   }
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Sanitized article content, search excerpts, and chat message Markdown before rendering.
  - Removed potentially malicious HTML while preserving highlighted search terms.
  - Prevented raw chat content from being displayed when rendering fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->