### PR TITLE
Reading time on vault cards is always 1 min read computed from the file path not the article

### DIFF
--- a/backend/internal/handlers/articles.go
+++ b/backend/internal/handlers/articles.go
@@ -80,6 +80,30 @@ func resolveArticleFromRecord(dataDir, recordArticlePath string) (string, error)
 	return resolveArticleFilePath(dataDir, rel)
 }
 
+func hydrateReadingTime(dataDir string, articles []repository.GormArticle) {
+	for i := range articles {
+		if dataDir == "" || articles[i].Article == "" {
+			if articles[i].ReadingTime == "" {
+				articles[i].ReadingTime = "1 min read"
+			}
+			continue
+		}
+		targetPath, err := resolveArticleFromRecord(dataDir, articles[i].Article)
+		if err != nil {
+			articles[i].ReadingTime = "1 min read"
+			continue
+		}
+		content, err := os.ReadFile(targetPath)
+		if err != nil {
+			articles[i].ReadingTime = "1 min read"
+			continue
+		}
+		words, rt := repository.CalculateReadingTime(string(content))
+		articles[i].WordCount = words
+		articles[i].ReadingTime = rt
+	}
+}
+
 func RegisterArticles(router fiber.Router, h *HandlerContext) {
 	router.Get("/getarticles", func(c *fiber.Ctx) error {
 		archivedParam := c.Query("archived")
@@ -122,6 +146,7 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 			})
 		}
 		hydrateReadingStatus(c.Context(), h, articles)
+		hydrateReadingTime(h.DataDir, articles)
 		return c.JSON(articles)
 	})
 
@@ -131,6 +156,22 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 			return c.Status(500).JSON(fiber.Map{
 				"error": "Failed to retrieve articles",
 			})
+		}
+		if h.DataDir != "" {
+			for i := range articles {
+				if articles[i].FilePath != "" {
+					if targetPath, err := resolveArticleFromRecord(h.DataDir, articles[i].FilePath); err == nil {
+						if content, err := os.ReadFile(targetPath); err == nil {
+							words, rt := repository.CalculateReadingTime(string(content))
+							articles[i].WordCount = words
+							articles[i].ReadingTime = rt
+						}
+					}
+				}
+				if articles[i].ReadingTime == "" {
+					articles[i].ReadingTime = "1 min read"
+				}
+			}
 		}
 		return c.JSON(articles)
 	})

--- a/backend/internal/handlers/articles.go
+++ b/backend/internal/handlers/articles.go
@@ -80,27 +80,9 @@ func resolveArticleFromRecord(dataDir, recordArticlePath string) (string, error)
 	return resolveArticleFilePath(dataDir, rel)
 }
 
-func hydrateReadingTime(dataDir string, articles []repository.GormArticle) {
+func hydrateReadingTime(articles []repository.GormArticle) {
 	for i := range articles {
-		if dataDir == "" || articles[i].Article == "" {
-			if articles[i].ReadingTime == "" {
-				articles[i].ReadingTime = "1 min read"
-			}
-			continue
-		}
-		targetPath, err := resolveArticleFromRecord(dataDir, articles[i].Article)
-		if err != nil {
-			articles[i].ReadingTime = "1 min read"
-			continue
-		}
-		content, err := os.ReadFile(targetPath)
-		if err != nil {
-			articles[i].ReadingTime = "1 min read"
-			continue
-		}
-		words, rt := repository.CalculateReadingTime(string(content))
-		articles[i].WordCount = words
-		articles[i].ReadingTime = rt
+		articles[i].ReadingTime = repository.ReadingTimeFromWords(articles[i].WordCount)
 	}
 }
 
@@ -146,7 +128,7 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 			})
 		}
 		hydrateReadingStatus(c.Context(), h, articles)
-		hydrateReadingTime(h.DataDir, articles)
+		hydrateReadingTime(articles)
 		return c.JSON(articles)
 	})
 
@@ -156,22 +138,6 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 			return c.Status(500).JSON(fiber.Map{
 				"error": "Failed to retrieve articles",
 			})
-		}
-		if h.DataDir != "" {
-			for i := range articles {
-				if articles[i].FilePath != "" {
-					if targetPath, err := resolveArticleFromRecord(h.DataDir, articles[i].FilePath); err == nil {
-						if content, err := os.ReadFile(targetPath); err == nil {
-							words, rt := repository.CalculateReadingTime(string(content))
-							articles[i].WordCount = words
-							articles[i].ReadingTime = rt
-						}
-					}
-				}
-				if articles[i].ReadingTime == "" {
-					articles[i].ReadingTime = "1 min read"
-				}
-			}
 		}
 		return c.JSON(articles)
 	})
@@ -543,6 +509,9 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 		if err := os.WriteFile(sourcePath, []byte(req.Content), 0644); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Could not save article"})
 		}
+
+		words, _ := repository.CalculateReadingTime(req.Content)
+		_ = h.DB.Model(&repository.GormArticle{}).Where("id = ?", article.ID).Update("word_count", words).Error
 
 		SyncArticleToFTS(h.DB, article.ID, article.Title, article.Tags, h.Logger)
 

--- a/backend/internal/handlers/articles.go
+++ b/backend/internal/handlers/articles.go
@@ -506,12 +506,23 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid article file path"})
 		}
 
+		previousContent, prevReadErr := os.ReadFile(sourcePath)
+
 		if err := os.WriteFile(sourcePath, []byte(req.Content), 0644); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Could not save article"})
 		}
 
 		words, _ := repository.CalculateReadingTime(req.Content)
-		_ = h.DB.Model(&repository.GormArticle{}).Where("id = ?", article.ID).Update("word_count", words).Error
+		res := h.DB.Model(&repository.GormArticle{}).Where("id = ?", article.ID).Update("word_count", words)
+		if res.Error != nil || res.RowsAffected == 0 {
+			if prevReadErr == nil {
+				_ = os.WriteFile(sourcePath, previousContent, 0644)
+			}
+			if res.Error != nil && h.Logger != nil {
+				h.Logger.Error("Failed to update article word_count in DB", zap.Int64("id", article.ID), zap.Error(res.Error))
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to update article word count"})
+		}
 
 		SyncArticleToFTS(h.DB, article.ID, article.Title, article.Tags, h.Logger)
 

--- a/backend/internal/handlers/articles_test.go
+++ b/backend/internal/handlers/articles_test.go
@@ -147,17 +147,14 @@ func TestArticleArchiveHandlers(t *testing.T) {
 
 	// Seed articles: 1 active, 1 archived
 	articles := []repository.GormArticle{
-		{ID: 101, Title: "Active Article", Article: "101.md", IsArchived: false},
-		{ID: 102, Title: "Archived Article", Article: "102.md", IsArchived: true},
+		{ID: 101, Title: "Active Article", Article: "101.md", IsArchived: false, WordCount: 400},
+		{ID: 102, Title: "Archived Article", Article: "102.md", IsArchived: true, WordCount: 200},
 	}
 	for _, a := range articles {
 		if err := db.Create(&a).Error; err != nil {
 			t.Fatalf("failed to seed article: %v", err)
 		}
 	}
-	// Write 400 words to 101.md to verify reading time
-	_ = os.MkdirAll(filepath.Join(tempDir, "articles"), 0755)
-	_ = os.WriteFile(filepath.Join(tempDir, "articles", "101.md"), []byte(strings.Repeat("word ", 400)), 0644)
 
 	repo := repository.NewGormRepository(db)
 	hCtx := &HandlerContext{

--- a/backend/internal/handlers/articles_test.go
+++ b/backend/internal/handlers/articles_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -389,5 +390,93 @@ func TestDeleteArticle_CleansArticleLinks(t *testing.T) {
 	db.Model(&repository.GormArticleLink{}).Where("source_id = 10 OR target_id = 10").Count(&count)
 	if count != 0 {
 		t.Errorf("expected 0 remaining article_links for article 10, got %d", count)
+	}
+}
+
+func TestEditArticle_UpdatesWordCount_And_RollsBack(t *testing.T) {
+	tempDir := t.TempDir()
+	articlesDir := filepath.Join(tempDir, "articles")
+	_ = os.MkdirAll(articlesDir, 0755)
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(tempDir, "test.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	_ = db.AutoMigrate(&repository.GormArticle{}, &repository.GormArticleLink{}, &repository.GormArticleStatusType{}, &repository.GormArticleStatus{})
+
+	origContent := "# Original Title\n\nShort content."
+	filePath := filepath.Join(articlesDir, "edit_test.md")
+	_ = os.WriteFile(filePath, []byte(origContent), 0644)
+
+	db.Create(&repository.GormArticle{
+		ID:        50,
+		Title:     "Original Title",
+		Article:   "/articles/edit_test.md",
+		WordCount: 4,
+	})
+
+	app := fiber.New()
+	api := app.Group("/api")
+	hCtx := &HandlerContext{
+		DB:      db,
+		DataDir: tempDir,
+		Logger:  zap.NewNop(),
+	}
+	RegisterArticles(api, hCtx)
+
+	// 1. Successful edit updates word_count
+	newContent := "# Original Title\n\n" + strings.Repeat("word ", 250)
+	bodyBytes, _ := json.Marshal(map[string]string{"content": newContent})
+	req := httptest.NewRequest("POST", "/api/edit/50", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, 5000)
+	if err != nil {
+		t.Fatalf("edit request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var updated repository.GormArticle
+	db.First(&updated, 50)
+	expectedWords, _ := repository.CalculateReadingTime(newContent)
+	if updated.WordCount != expectedWords {
+		t.Errorf("expected WordCount %d, got %d", expectedWords, updated.WordCount)
+	}
+
+	diskBytes, _ := os.ReadFile(filePath)
+	if string(diskBytes) != newContent {
+		t.Errorf("expected file content to be updated on disk")
+	}
+
+	// 2. Failure rollback: when the article row is deleted before DB update executes
+	currentContentOnDisk := string(diskBytes)
+	db.Exec("DELETE FROM articles WHERE id = 50")
+
+	failingContent := "# Failing Title\n\nContent that should be reverted."
+	failBody, _ := json.Marshal(map[string]string{"content": failingContent})
+	failReq := httptest.NewRequest("POST", "/api/edit/50", bytes.NewReader(failBody))
+	failReq.Header.Set("Content-Type", "application/json")
+
+	// Pre-create article in memory with matching id for handler to find initially, or drop table to trigger DB update error
+	db.Exec("DROP TABLE articles")
+
+	failResp, err := app.Test(failReq, 5000)
+	if err != nil {
+		t.Fatalf("edit request failed: %v", err)
+	}
+	defer failResp.Body.Close()
+
+	if failResp.StatusCode == 200 {
+		t.Errorf("expected non-200 status when DB table is missing, got %d", failResp.StatusCode)
+	}
+
+	// Verify disk file was restored to previous content
+	restoredBytes, _ := os.ReadFile(filePath)
+	if string(restoredBytes) != currentContentOnDisk {
+		t.Errorf("expected disk file to be restored to %q, got %q", currentContentOnDisk, string(restoredBytes))
 	}
 }

--- a/backend/internal/handlers/articles_test.go
+++ b/backend/internal/handlers/articles_test.go
@@ -155,6 +155,9 @@ func TestArticleArchiveHandlers(t *testing.T) {
 			t.Fatalf("failed to seed article: %v", err)
 		}
 	}
+	// Write 400 words to 101.md to verify reading time
+	_ = os.MkdirAll(filepath.Join(tempDir, "articles"), 0755)
+	_ = os.WriteFile(filepath.Join(tempDir, "articles", "101.md"), []byte(strings.Repeat("word ", 400)), 0644)
 
 	repo := repository.NewGormRepository(db)
 	hCtx := &HandlerContext{
@@ -184,6 +187,12 @@ func TestArticleArchiveHandlers(t *testing.T) {
 		}
 		if len(list) != 1 || list[0].ID != 101 {
 			t.Fatalf("expected 1 active article with ID 101, got: %+v", list)
+		}
+		if list[0].ReadingTime != "2 min read" {
+			t.Errorf("expected ReadingTime = %q, got %q", "2 min read", list[0].ReadingTime)
+		}
+		if list[0].WordCount != 400 {
+			t.Errorf("expected WordCount = %d, got %d", 400, list[0].WordCount)
 		}
 	})
 

--- a/backend/internal/handlers/keys_test.go
+++ b/backend/internal/handlers/keys_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 
 func setupKeysTestApp(t *testing.T) (*fiber.App, *HandlerContext, *gorm.DB) {
 	tempDir := t.TempDir()
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(filepath.Join(tempDir, "keys_test.db")), &gorm.Config{})
 	require.NoError(t, err)
 
 	require.NoError(t, db.AutoMigrate(&repository.APIKey{}))

--- a/backend/internal/handlers/migration.go
+++ b/backend/internal/handlers/migration.go
@@ -165,3 +165,51 @@ func MigrateLegacyArticleTags(db *gorm.DB, dataDir string, logger *zap.Logger) (
 
 	return migratedCount, nil
 }
+
+// MigrateLegacyWordCounts scans all articles in SQLite without a word_count. If the corresponding markdown
+// file exists on disk, it calculates and stores the word count in the database.
+func MigrateLegacyWordCounts(db *gorm.DB, dataDir string, logger *zap.Logger) (int, error) {
+	if db == nil {
+		return 0, nil
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	var articles []repository.GormArticle
+	if err := db.Where("deleted_at IS NULL AND (word_count = 0 OR word_count IS NULL)").Find(&articles).Error; err != nil {
+		return 0, fmt.Errorf("failed to fetch articles for word count migration: %w", err)
+	}
+
+	migratedCount := 0
+	for _, a := range articles {
+		if a.Article == "" {
+			continue
+		}
+
+		filePath, err := resolveArticleFromRecord(dataDir, a.Article)
+		if err != nil {
+			continue
+		}
+
+		contentBytes, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+
+		words, _ := repository.CalculateReadingTime(string(contentBytes))
+		if words > 0 {
+			if err := db.Model(&repository.GormArticle{}).Where("id = ?", a.ID).Update("word_count", words).Error; err != nil {
+				logger.Warn("Failed to update word_count in database", zap.Int64("id", a.ID), zap.Error(err))
+				continue
+			}
+			migratedCount++
+		}
+	}
+
+	if migratedCount > 0 {
+		logger.Info("Migrated article word counts", zap.Int("count", migratedCount))
+	}
+
+	return migratedCount, nil
+}

--- a/backend/internal/handlers/migration_test.go
+++ b/backend/internal/handlers/migration_test.go
@@ -282,3 +282,41 @@ tags: [google, gemini, legal tech, artificial intelligence, enterprise ai]
 		t.Errorf("file missing sanitized hyphenated tags:\n%s", updatedFileStr)
 	}
 }
+
+func TestMigrateLegacyWordCounts(t *testing.T) {
+	tempDir := t.TempDir()
+	articlesDir := filepath.Join(tempDir, "articles")
+	_ = os.MkdirAll(articlesDir, 0755)
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(tempDir, "test.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = db.AutoMigrate(&repository.GormArticle{}, &repository.GormArticleStatusType{}, &repository.GormArticleStatus{})
+
+	// 1. Seed article with word_count = 0 and file on disk
+	articleContent := "---\ntitle: Sample Note\n---\n\n" + strings.Repeat("word ", 350)
+	filePath := filepath.Join(articlesDir, "Sample Note.md")
+	_ = os.WriteFile(filePath, []byte(articleContent), 0644)
+
+	db.Create(&repository.GormArticle{
+		ID:        301,
+		Title:     "Sample Note",
+		Article:   "/articles/Sample Note.md",
+		WordCount: 0,
+	})
+
+	count, err := MigrateLegacyWordCounts(db, tempDir, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected word count migration error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 migrated article, got %d", count)
+	}
+
+	var updated repository.GormArticle
+	db.First(&updated, 301)
+	if updated.WordCount != 350 {
+		t.Errorf("expected updated DB word_count 350, got %d", updated.WordCount)
+	}
+}

--- a/backend/internal/ingest/ingester.go
+++ b/backend/internal/ingest/ingester.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"example.com/backend/internal/repository"
 )
 
 type Ingester struct {
@@ -153,13 +155,16 @@ func (ing *Ingester) Ingest(ctx context.Context, req IngestRequest) (*IngestedAr
 	}
 
 	// 8. Persist to ArticleRepository
+	words, rt := repository.CalculateReadingTime(markdownDoc)
 	article := &IngestedArticle{
-		ID:        filenameID,
-		Title:     extracted.Title,
-		ImagePath: coverImagePath,
-		FilePath:  relFilePath,
-		Tags:      tagsString,
-		SourceURL: trimmedURL,
+		ID:          filenameID,
+		Title:       extracted.Title,
+		ImagePath:   coverImagePath,
+		FilePath:    relFilePath,
+		Tags:        tagsString,
+		SourceURL:   trimmedURL,
+		WordCount:   words,
+		ReadingTime: rt,
 	}
 
 	if err := ing.repo.SaveArticle(ctx, article); err != nil {

--- a/backend/internal/repository/gorm_repo.go
+++ b/backend/internal/repository/gorm_repo.go
@@ -84,10 +84,10 @@ type GormArticle struct {
 	Title           string  `json:"title"`
 	Tags            string  `json:"tags"`
 	IsArchived      bool    `gorm:"default:false;index" json:"is_archived"`
+	WordCount       int     `gorm:"default:0" json:"word_count"`
 	ReadingStatus   string  `gorm:"-" json:"reading_status"`
 	ReadingProgress float64 `gorm:"-" json:"reading_progress"`
 	ReadingTime     string  `gorm:"-" json:"reading_time"`
-	WordCount       int     `gorm:"-" json:"word_count"`
 }
 
 func (GormArticle) TableName() string {
@@ -136,13 +136,15 @@ func (r *GormRepository) FindBySourceURL(ctx context.Context, sourceURL string) 
 		return nil, err
 	}
 	return &ArticleRecord{
-		ID:         a.ID,
-		Title:      a.Title,
-		ImagePath:  a.Image,
-		FilePath:   a.Article,
-		Tags:       a.Tags,
-		SourceURL:  sourceURL,
-		IsArchived: a.IsArchived,
+		ID:          a.ID,
+		Title:       a.Title,
+		ImagePath:   a.Image,
+		FilePath:    a.Article,
+		Tags:        a.Tags,
+		SourceURL:   sourceURL,
+		IsArchived:  a.IsArchived,
+		WordCount:   a.WordCount,
+		ReadingTime: ReadingTimeFromWords(a.WordCount),
 	}, nil
 }
 
@@ -155,12 +157,14 @@ func (r *GormRepository) FindByID(ctx context.Context, id int64) (*ArticleRecord
 		return nil, err
 	}
 	return &ArticleRecord{
-		ID:         a.ID,
-		Title:      a.Title,
-		ImagePath:  a.Image,
-		FilePath:   a.Article,
-		Tags:       a.Tags,
-		IsArchived: a.IsArchived,
+		ID:          a.ID,
+		Title:       a.Title,
+		ImagePath:   a.Image,
+		FilePath:    a.Article,
+		Tags:        a.Tags,
+		IsArchived:  a.IsArchived,
+		WordCount:   a.WordCount,
+		ReadingTime: ReadingTimeFromWords(a.WordCount),
 	}, nil
 }
 
@@ -172,6 +176,7 @@ func (r *GormRepository) SaveArticle(ctx context.Context, a *ArticleRecord) erro
 		Article:    a.FilePath,
 		Tags:       a.Tags,
 		IsArchived: a.IsArchived,
+		WordCount:  a.WordCount,
 	}
 	return r.db.WithContext(ctx).Create(&article).Error
 }
@@ -193,8 +198,8 @@ func (r *GormRepository) GetAllArticles(ctx context.Context) ([]ArticleRecord, e
 			IsArchived:      a.IsArchived,
 			ReadingStatus:   a.ReadingStatus,
 			ReadingProgress: a.ReadingProgress,
-			ReadingTime:     a.ReadingTime,
 			WordCount:       a.WordCount,
+			ReadingTime:     ReadingTimeFromWords(a.WordCount),
 		}
 	}
 	return result, nil
@@ -217,8 +222,8 @@ func (r *GormRepository) GetArchivedArticles(ctx context.Context) ([]ArticleReco
 			IsArchived:      a.IsArchived,
 			ReadingStatus:   a.ReadingStatus,
 			ReadingProgress: a.ReadingProgress,
-			ReadingTime:     a.ReadingTime,
 			WordCount:       a.WordCount,
+			ReadingTime:     ReadingTimeFromWords(a.WordCount),
 		}
 	}
 	return result, nil

--- a/backend/internal/repository/gorm_repo.go
+++ b/backend/internal/repository/gorm_repo.go
@@ -86,6 +86,8 @@ type GormArticle struct {
 	IsArchived      bool    `gorm:"default:false;index" json:"is_archived"`
 	ReadingStatus   string  `gorm:"-" json:"reading_status"`
 	ReadingProgress float64 `gorm:"-" json:"reading_progress"`
+	ReadingTime     string  `gorm:"-" json:"reading_time"`
+	WordCount       int     `gorm:"-" json:"word_count"`
 }
 
 func (GormArticle) TableName() string {
@@ -183,12 +185,16 @@ func (r *GormRepository) GetAllArticles(ctx context.Context) ([]ArticleRecord, e
 	result := make([]ArticleRecord, len(articles))
 	for i, a := range articles {
 		result[i] = ArticleRecord{
-			ID:         a.ID,
-			Title:      a.Title,
-			ImagePath:  a.Image,
-			FilePath:   a.Article,
-			Tags:       a.Tags,
-			IsArchived: a.IsArchived,
+			ID:              a.ID,
+			Title:           a.Title,
+			ImagePath:       a.Image,
+			FilePath:        a.Article,
+			Tags:            a.Tags,
+			IsArchived:      a.IsArchived,
+			ReadingStatus:   a.ReadingStatus,
+			ReadingProgress: a.ReadingProgress,
+			ReadingTime:     a.ReadingTime,
+			WordCount:       a.WordCount,
 		}
 	}
 	return result, nil
@@ -203,12 +209,16 @@ func (r *GormRepository) GetArchivedArticles(ctx context.Context) ([]ArticleReco
 	result := make([]ArticleRecord, len(articles))
 	for i, a := range articles {
 		result[i] = ArticleRecord{
-			ID:         a.ID,
-			Title:      a.Title,
-			ImagePath:  a.Image,
-			FilePath:   a.Article,
-			Tags:       a.Tags,
-			IsArchived: a.IsArchived,
+			ID:              a.ID,
+			Title:           a.Title,
+			ImagePath:       a.Image,
+			FilePath:        a.Article,
+			Tags:            a.Tags,
+			IsArchived:      a.IsArchived,
+			ReadingStatus:   a.ReadingStatus,
+			ReadingProgress: a.ReadingProgress,
+			ReadingTime:     a.ReadingTime,
+			WordCount:       a.WordCount,
 		}
 	}
 	return result, nil

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"strings"
 )
 
@@ -25,6 +27,21 @@ func IsMOCArticle(title, tags string) bool {
 	return false
 }
 
+// CalculateReadingTime computes the word count and estimated reading time string (e.g. "5 min read")
+// for markdown content assuming an average reading speed of 200 words per minute.
+func CalculateReadingTime(content string) (int, string) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return 0, "1 min read"
+	}
+	words := len(strings.Fields(trimmed))
+	minutes := int(math.Ceil(float64(words) / 200.0))
+	if minutes < 1 {
+		minutes = 1
+	}
+	return words, fmt.Sprintf("%d min read", minutes)
+}
+
 type ArticleRecord struct {
 	ID              int64   `json:"id"`
 	Title           string  `json:"title"`
@@ -35,6 +52,8 @@ type ArticleRecord struct {
 	IsArchived      bool    `json:"is_archived"`
 	ReadingStatus   string  `json:"reading_status"`
 	ReadingProgress float64 `json:"reading_progress"`
+	ReadingTime     string  `json:"reading_time"`
+	WordCount       int     `json:"word_count"`
 }
 
 type LinkRecord struct {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -27,19 +27,55 @@ func IsMOCArticle(title, tags string) bool {
 	return false
 }
 
+// ReadingTimeFromWords computes the formatted reading time string (e.g. "5 min read")
+// for a given word count assuming 200 words per minute.
+func ReadingTimeFromWords(words int) string {
+	if words <= 0 {
+		return "1 min read"
+	}
+	minutes := int(math.Ceil(float64(words) / 200.0))
+	if minutes < 1 {
+		minutes = 1
+	}
+	return fmt.Sprintf("%d min read", minutes)
+}
+
 // CalculateReadingTime computes the word count and estimated reading time string (e.g. "5 min read")
-// for markdown content assuming an average reading speed of 200 words per minute.
+// for markdown content. It strips leading YAML frontmatter (--- ... ---) and counts whitespace-separated words.
 func CalculateReadingTime(content string) (int, string) {
 	trimmed := strings.TrimSpace(content)
 	if trimmed == "" {
 		return 0, "1 min read"
 	}
-	words := len(strings.Fields(trimmed))
-	minutes := int(math.Ceil(float64(words) / 200.0))
-	if minutes < 1 {
-		minutes = 1
+
+	// Strip leading YAML frontmatter if present
+	if strings.HasPrefix(trimmed, "---") {
+		rest := trimmed[3:]
+		if idx := strings.Index(rest, "\n---"); idx != -1 {
+			trimmed = strings.TrimSpace(rest[idx+4:])
+		} else if idx := strings.Index(rest, "\r\n---"); idx != -1 {
+			trimmed = strings.TrimSpace(rest[idx+5:])
+		}
 	}
-	return words, fmt.Sprintf("%d min read", minutes)
+
+	if trimmed == "" {
+		return 0, "1 min read"
+	}
+
+	// Single-pass word counter (zero slice allocations)
+	words := 0
+	inWord := false
+	for i := 0; i < len(trimmed); i++ {
+		b := trimmed[i]
+		if b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f' || b == '\v' {
+			inWord = false
+		} else if !inWord {
+			inWord = true
+			words++
+		}
+	}
+
+	return words, ReadingTimeFromWords(words)
 }
 
 type ArticleRecord struct {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"unicode"
 )
 
 var (
@@ -62,12 +63,11 @@ func CalculateReadingTime(content string) (int, string) {
 		return 0, "1 min read"
 	}
 
-	// Single-pass word counter (zero slice allocations)
+	// Single-pass word counter over runes
 	words := 0
 	inWord := false
-	for i := 0; i < len(trimmed); i++ {
-		b := trimmed[i]
-		if b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f' || b == '\v' {
+	for _, r := range trimmed {
+		if unicode.IsSpace(r) {
 			inWord = false
 		} else if !inWord {
 			inWord = true

--- a/backend/internal/repository/repository_test.go
+++ b/backend/internal/repository/repository_test.go
@@ -1,0 +1,72 @@
+package repository
+
+import "testing"
+
+func TestCalculateReadingTime(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantWords    int
+		wantReadTime string
+	}{
+		{
+			name:         "empty content",
+			content:      "",
+			wantWords:    0,
+			wantReadTime: "1 min read",
+		},
+		{
+			name:         "whitespace only",
+			content:      "   \n\t  \n ",
+			wantWords:    0,
+			wantReadTime: "1 min read",
+		},
+		{
+			name:         "short content under 200 words",
+			content:      "This is a short note with eight words.",
+			wantWords:    8,
+			wantReadTime: "1 min read",
+		},
+		{
+			name:         "exact 200 words",
+			content:      generateWords(200),
+			wantWords:    200,
+			wantReadTime: "1 min read",
+		},
+		{
+			name:         "201 words rounds up to 2 min read",
+			content:      generateWords(201),
+			wantWords:    201,
+			wantReadTime: "2 min read",
+		},
+		{
+			name:         "1000 words yields 5 min read",
+			content:      generateWords(1000),
+			wantWords:    1000,
+			wantReadTime: "5 min read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			words, readTime := CalculateReadingTime(tt.content)
+			if words != tt.wantWords {
+				t.Errorf("CalculateReadingTime() words = %v, want %v", words, tt.wantWords)
+			}
+			if readTime != tt.wantReadTime {
+				t.Errorf("CalculateReadingTime() readTime = %v, want %v", readTime, tt.wantReadTime)
+			}
+		})
+	}
+}
+
+func generateWords(n int) string {
+	res := ""
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			res += " "
+		}
+		res += "word"
+	}
+	return res
+}

--- a/backend/internal/repository/repository_test.go
+++ b/backend/internal/repository/repository_test.go
@@ -51,6 +51,12 @@ func TestCalculateReadingTime(t *testing.T) {
 			wantWords:    7,
 			wantReadTime: "1 min read",
 		},
+		{
+			name:         "unicode whitespace delimiters",
+			content:      "word1\u00A0word2\u2003word3\u3000word4",
+			wantWords:    4,
+			wantReadTime: "1 min read",
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/repository/repository_test.go
+++ b/backend/internal/repository/repository_test.go
@@ -45,6 +45,12 @@ func TestCalculateReadingTime(t *testing.T) {
 			wantWords:    1000,
 			wantReadTime: "5 min read",
 		},
+		{
+			name:         "frontmatter is stripped from word count",
+			content:      "---\ntitle: \"Super Long Title With Many Metadata Words\"\ntags: [golang, devops, kubernetes]\nsource: \"https://example.com/foo/bar\"\n---\n\nActual body text here with six words.",
+			wantWords:    7,
+			wantReadTime: "1 min read",
+		},
 	}
 
 	for _, tt := range tests {
@@ -57,6 +63,15 @@ func TestCalculateReadingTime(t *testing.T) {
 				t.Errorf("CalculateReadingTime() readTime = %v, want %v", readTime, tt.wantReadTime)
 			}
 		})
+	}
+}
+
+func BenchmarkCalculateReadingTime(b *testing.B) {
+	content := "---\ntitle: \"Sample\"\ntags: [test]\n---\n\n" + generateWords(2000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = CalculateReadingTime(content)
 	}
 }
 

--- a/backend/internal/vault/vault.go
+++ b/backend/internal/vault/vault.go
@@ -185,9 +185,12 @@ func (v *DefaultVault) SaveArticle(ctx context.Context, input NoteInput) (*repos
 
 	// 3. Persist updated metadata and sync FTS
 	err := v.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		words, rt := repository.CalculateReadingTime(input.Content)
 		article.Title = input.Title
 		article.Tags = input.Tags
 		article.Article = relPath
+		article.WordCount = words
+		article.ReadingTime = rt
 		if input.ImagePath != "" {
 			article.Image = input.ImagePath
 		}
@@ -340,7 +343,13 @@ func (v *DefaultVault) GetArticle(ctx context.Context, id int64) (*repository.Go
 		return &article, "", fmt.Errorf("failed to read article file %s: %w", absPath, err)
 	}
 
-	article.WordCount, article.ReadingTime = repository.CalculateReadingTime(string(bytes))
+	if article.WordCount <= 0 {
+		article.WordCount, article.ReadingTime = repository.CalculateReadingTime(string(bytes))
+		_ = v.db.WithContext(ctx).Model(&repository.GormArticle{}).Where("id = ?", article.ID).Update("word_count", article.WordCount)
+	} else {
+		article.ReadingTime = repository.ReadingTimeFromWords(article.WordCount)
+	}
+
 	return &article, string(bytes), nil
 }
 
@@ -386,19 +395,7 @@ func (v *DefaultVault) ListArticles(ctx context.Context, filter ArticleFilter) (
 
 func (v *DefaultVault) hydrateReadingTime(articles []repository.GormArticle) {
 	for i := range articles {
-		filePath, err := v.ResolveFilePath(articles[i].Article)
-		if err != nil {
-			articles[i].ReadingTime = "1 min read"
-			continue
-		}
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			articles[i].ReadingTime = "1 min read"
-			continue
-		}
-		words, rt := repository.CalculateReadingTime(string(content))
-		articles[i].WordCount = words
-		articles[i].ReadingTime = rt
+		articles[i].ReadingTime = repository.ReadingTimeFromWords(articles[i].WordCount)
 	}
 }
 

--- a/backend/internal/vault/vault.go
+++ b/backend/internal/vault/vault.go
@@ -345,7 +345,9 @@ func (v *DefaultVault) GetArticle(ctx context.Context, id int64) (*repository.Go
 
 	if article.WordCount <= 0 {
 		article.WordCount, article.ReadingTime = repository.CalculateReadingTime(string(bytes))
-		_ = v.db.WithContext(ctx).Model(&repository.GormArticle{}).Where("id = ?", article.ID).Update("word_count", article.WordCount)
+		_ = v.db.WithContext(ctx).Model(&repository.GormArticle{}).
+			Where("id = ? AND updated_at = ?", article.ID, article.UpdatedAt).
+			Update("word_count", article.WordCount)
 	} else {
 		article.ReadingTime = repository.ReadingTimeFromWords(article.WordCount)
 	}

--- a/backend/internal/vault/vault.go
+++ b/backend/internal/vault/vault.go
@@ -340,6 +340,7 @@ func (v *DefaultVault) GetArticle(ctx context.Context, id int64) (*repository.Go
 		return &article, "", fmt.Errorf("failed to read article file %s: %w", absPath, err)
 	}
 
+	article.WordCount, article.ReadingTime = repository.CalculateReadingTime(string(bytes))
 	return &article, string(bytes), nil
 }
 
@@ -378,8 +379,27 @@ func (v *DefaultVault) ListArticles(ctx context.Context, filter ArticleFilter) (
 	if err := v.hydrateReadingStatus(ctx, articles); err != nil {
 		v.logger.Error("Failed to hydrate reading status", zap.Error(err))
 	}
+	v.hydrateReadingTime(articles)
 
 	return articles, nil
+}
+
+func (v *DefaultVault) hydrateReadingTime(articles []repository.GormArticle) {
+	for i := range articles {
+		filePath, err := v.ResolveFilePath(articles[i].Article)
+		if err != nil {
+			articles[i].ReadingTime = "1 min read"
+			continue
+		}
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			articles[i].ReadingTime = "1 min read"
+			continue
+		}
+		words, rt := repository.CalculateReadingTime(string(content))
+		articles[i].WordCount = words
+		articles[i].ReadingTime = rt
+	}
 }
 
 func (v *DefaultVault) hydrateReadingStatus(ctx context.Context, articles []repository.GormArticle) error {

--- a/backend/internal/vault/vault_test.go
+++ b/backend/internal/vault/vault_test.go
@@ -367,3 +367,89 @@ func TestVault_ListArticles_HydratesReadingTime(t *testing.T) {
 		t.Errorf("ListArticles WordCount = %d, want 600", list[0].WordCount)
 	}
 }
+
+func TestVault_GetArticle_ReadRacingWithEdit(t *testing.T) {
+	v, db, tempDir, _ := setupTestVaultEnv(t)
+	ctx := context.Background()
+
+	// 1. Initial article with 0 word_count in DB (simulating legacy or uncomputed note)
+	filePath := filepath.Join(tempDir, "articles", "Race Note.md")
+	_ = os.MkdirAll(filepath.Dir(filePath), 0755)
+	initialContent := "Initial content with four words."
+	_ = os.WriteFile(filePath, []byte(initialContent), 0644)
+
+	initialArt := repository.GormArticle{
+		Title:     "Race Note",
+		Article:   "/articles/Race Note.md",
+		WordCount: 0,
+	}
+	if err := db.Create(&initialArt).Error; err != nil {
+		t.Fatalf("failed to create initial article: %v", err)
+	}
+
+	// 2. An edit occurs (e.g. SaveArticle) updating the row and content with 100 words
+	editedContent := strings.Repeat("word ", 100)
+	_, err := v.SaveArticle(ctx, NoteInput{
+		ID:      initialArt.ID,
+		Title:   "Race Note",
+		Content: editedContent,
+	})
+	if err != nil {
+		t.Fatalf("failed to save edited article: %v", err)
+	}
+
+	// Capture the edited article state from DB
+	var editedArt repository.GormArticle
+	if err := db.First(&editedArt, initialArt.ID).Error; err != nil {
+		t.Fatalf("failed to get edited article: %v", err)
+	}
+	if editedArt.WordCount != 100 {
+		t.Fatalf("expected edited article word_count 100, got %d", editedArt.WordCount)
+	}
+
+	// 3. Now simulate the stale read's word_count update attempting to overwrite with stale initialArt.UpdatedAt
+	// Even if an in-flight GetArticle tried to write stale word_count (e.g. 5), compare-and-update prevents overwriting
+	staleUpdateRes := db.Model(&repository.GormArticle{}).
+		Where("id = ? AND updated_at = ?", initialArt.ID, initialArt.UpdatedAt).
+		Update("word_count", 5)
+
+	if staleUpdateRes.RowsAffected != 0 {
+		t.Fatalf("expected 0 rows affected on stale compare-and-update, got %d", staleUpdateRes.RowsAffected)
+	}
+
+	// Verify the database word count was preserved at 100
+	var currentArt repository.GormArticle
+	if err := db.First(&currentArt, initialArt.ID).Error; err != nil {
+		t.Fatalf("failed to fetch current article: %v", err)
+	}
+	if currentArt.WordCount != 100 {
+		t.Errorf("expected word_count 100, got %d (stale write overwritten)", currentArt.WordCount)
+	}
+
+	// 4. Calling GetArticle on an uncomputed note successfully calculates and updates word count
+	uncomputedPath := filepath.Join(tempDir, "articles", "Uncomputed Note.md")
+	_ = os.WriteFile(uncomputedPath, []byte("One two three four five six seven"), 0644)
+	uncomputedArt := repository.GormArticle{
+		Title:     "Uncomputed Note",
+		Article:   "/articles/Uncomputed Note.md",
+		WordCount: 0,
+	}
+	db.Create(&uncomputedArt)
+
+	gotArt, _, err := v.GetArticle(ctx, uncomputedArt.ID)
+	if err != nil {
+		t.Fatalf("GetArticle failed: %v", err)
+	}
+	if gotArt.WordCount != 7 {
+		t.Errorf("expected WordCount 7, got %d", gotArt.WordCount)
+	}
+	if gotArt.ReadingTime != "1 min read" {
+		t.Errorf("expected ReadingTime '1 min read', got %q", gotArt.ReadingTime)
+	}
+
+	var dbCheck repository.GormArticle
+	db.First(&dbCheck, uncomputedArt.ID)
+	if dbCheck.WordCount != 7 {
+		t.Errorf("expected persisted WordCount 7, got %d", dbCheck.WordCount)
+	}
+}

--- a/backend/internal/vault/vault_test.go
+++ b/backend/internal/vault/vault_test.go
@@ -324,3 +324,46 @@ func TestVault_SaveArticle_AllocatesUniqueIDsAndDistinctPaths(t *testing.T) {
 		t.Errorf("expected disk file for art2 at %s", diskPath2)
 	}
 }
+
+func TestVault_ListArticles_HydratesReadingTime(t *testing.T) {
+	v, _, _, _ := setupTestVaultEnv(t)
+	ctx := context.Background()
+
+	// Create an article with 600 words (~3 min read)
+	longContent := strings.Repeat("word ", 600)
+	art, err := v.SaveArticle(ctx, NoteInput{
+		Title:   "Long Read Article",
+		Content: longContent,
+		Tags:    "test",
+	})
+	if err != nil {
+		t.Fatalf("failed to save article: %v", err)
+	}
+
+	// 1. Check GetArticle
+	gotArt, _, err := v.GetArticle(ctx, art.ID)
+	if err != nil {
+		t.Fatalf("failed to get article: %v", err)
+	}
+	if gotArt.ReadingTime != "3 min read" {
+		t.Errorf("GetArticle ReadingTime = %q, want %q", gotArt.ReadingTime, "3 min read")
+	}
+	if gotArt.WordCount != 600 {
+		t.Errorf("GetArticle WordCount = %d, want 600", gotArt.WordCount)
+	}
+
+	// 2. Check ListArticles
+	list, err := v.ListArticles(ctx, ArticleFilter{})
+	if err != nil {
+		t.Fatalf("failed to list articles: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 article in list, got %d", len(list))
+	}
+	if list[0].ReadingTime != "3 min read" {
+		t.Errorf("ListArticles ReadingTime = %q, want %q", list[0].ReadingTime, "3 min read")
+	}
+	if list[0].WordCount != 600 {
+		t.Errorf("ListArticles WordCount = %d, want 600", list[0].WordCount)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -96,6 +96,7 @@ func initDB() *gorm.DB {
 	}
 	handlers.MigrateLegacyArticleFilenames(db, getDataDir(), logger)
 	handlers.MigrateLegacyArticleTags(db, getDataDir(), logger)
+	handlers.MigrateLegacyWordCounts(db, getDataDir(), logger)
 
 	return db
 }
@@ -150,6 +151,7 @@ func setupApp(customDB ...*gorm.DB) *fiber.App {
 	if err := repository.EnsureArticleStatusTypes(db); err != nil && logger != nil {
 		logger.Error("Failed to seed reading status types", zap.Error(err))
 	}
+	handlers.MigrateLegacyWordCounts(db, getDataDir(), logger)
 
 	dataDirectory := getDataDir()
 	settingsStore := handlers.NewSettingsStore(dataDirectory, logger)

--- a/frontend/src/components/Article.vue
+++ b/frontend/src/components/Article.vue
@@ -30,6 +30,8 @@ interface ArticleData {
   tags: string
   reading_status?: string
   reading_progress?: number
+  reading_time?: string
+  word_count?: number
 }
 
 const allArticles = ref<ArticleData[]>([])

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -16,6 +16,8 @@ interface Article {
   parsedTags: string[]
   reading_status?: string
   reading_progress?: number
+  reading_time?: string
+  word_count?: number
 }
 
 defineProps<{ msg?: string }>()
@@ -119,9 +121,12 @@ function formatTimelineDate(unixTs: number): { month: string; day: string; year:
   return { month, day, year }
 }
 
-function getReadingTime(text: string): string {
-  if (!text) return '1 min'
-  const words = text.trim().split(/\s+/).length
+function getReadingTime(articleOrText?: Article | string | null): string {
+  if (!articleOrText) return '1 min read'
+  if (typeof articleOrText === 'object') {
+    return articleOrText.reading_time || '1 min read'
+  }
+  const words = articleOrText.trim().split(/\s+/).filter(Boolean).length
   const minutes = Math.max(1, Math.ceil(words / 200))
   return `${minutes} min read`
 }
@@ -639,7 +644,7 @@ const secondaryArticles = computed(() => {
                   <span>•</span>
                   <span>{{ formatDate(leadArticle.ID) || 'Recent' }}</span>
                   <span>•</span>
-                  <span>{{ getReadingTime(leadArticle.article) }}</span>
+                  <span>{{ getReadingTime(leadArticle) }}</span>
                   <span>&bull;</span>
                   <ArticleProgressLabel
                     variant="meta"
@@ -797,7 +802,7 @@ const secondaryArticles = computed(() => {
                   #{{ String(idx + 2).padStart(2, '0') }}
                 </span>
                 <span class="text-[10px] font-mono text-white/70">
-                  {{ getReadingTime(article.article) }}
+                  {{ getReadingTime(article) }}
                 </span>
               </div>
             </div>
@@ -823,7 +828,7 @@ const secondaryArticles = computed(() => {
                 {{ formatShortDate(article.ID) || `ID #${article.ID}` }}
               </span>
               <span class="text-[10px] font-mono text-white/85 drop-shadow-sm">
-                {{ getReadingTime(article.article) }}
+                {{ getReadingTime(article) }}
               </span>
             </div>
           </div>
@@ -981,7 +986,7 @@ const secondaryArticles = computed(() => {
 
                 <!-- Reading Time -->
                 <span class="text-[11px] text-gray-400 dark:text-gray-500 font-mono">
-                  {{ getReadingTime(article.article) }}
+                  {{ getReadingTime(article) }}
                 </span>
 
                 <!-- Reading Status -->

--- a/frontend/src/views/ArchiveView.vue
+++ b/frontend/src/views/ArchiveView.vue
@@ -14,6 +14,8 @@ interface Article {
   parsedTags: string[]
   reading_status?: string
   reading_progress?: number
+  reading_time?: string
+  word_count?: number
 }
 
 const articles = ref<Article[]>([])
@@ -129,9 +131,12 @@ function formatTimelineDate(unixTs: number): { month: string; day: string; year:
   return { month, day, year }
 }
 
-function getReadingTime(text: string): string {
-  if (!text) return '1 min'
-  const words = text.trim().split(/\s+/).length
+function getReadingTime(articleOrText?: Article | string | null): string {
+  if (!articleOrText) return '1 min read'
+  if (typeof articleOrText === 'object') {
+    return articleOrText.reading_time || '1 min read'
+  }
+  const words = articleOrText.trim().split(/\s+/).filter(Boolean).length
   const minutes = Math.max(1, Math.ceil(words / 200))
   return `${minutes} min read`
 }
@@ -406,7 +411,7 @@ const secondaryArticles = computed(() => {
                   <span>•</span>
                   <span>{{ formatDate(leadArticle.ID) || 'Recent' }}</span>
                   <span>•</span>
-                  <span>{{ getReadingTime(leadArticle.article) }}</span>
+                  <span>{{ getReadingTime(leadArticle) }}</span>
                   <span>•</span>
                   <ArticleProgressLabel
                     variant="meta"
@@ -570,7 +575,7 @@ const secondaryArticles = computed(() => {
                 {{ formatShortDate(article.ID) || `ID #${article.ID}` }}
               </span>
               <span class="text-[10px] font-mono text-white/85 drop-shadow-sm">
-                {{ getReadingTime(article.article) }}
+                {{ getReadingTime(article) }}
               </span>
             </div>
           </div>
@@ -710,7 +715,7 @@ const secondaryArticles = computed(() => {
                 </span>
 
                 <span class="text-[11px] text-gray-400 dark:text-gray-500 font-mono">
-                  {{ getReadingTime(article.article) }}
+                  {{ getReadingTime(article) }}
                 </span>
 
                 <ArticleProgressLabel


### PR DESCRIPTION
Fixes #215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Articles now include estimated reading time and word count.
  - Reading-time estimates appear consistently across article lists, home views, and archived articles.
  - Newly saved and edited articles automatically update their word counts and reading estimates.
  - Existing articles receive word counts automatically when available.

- **Bug Fixes**
  - Improved reading-time calculations for empty content and formatted text.

- **Tests**
  - Added coverage for reading-time calculations, migration, and article display data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->