### PR TITLE
feat(vault): show MOC collection progress instead of a permanent "New!"

### DIFF
--- a/backend/internal/handlers/articles.go
+++ b/backend/internal/handlers/articles.go
@@ -128,6 +128,7 @@ func RegisterArticles(router fiber.Router, h *HandlerContext) {
 			})
 		}
 		hydrateReadingStatus(c.Context(), h, articles)
+		hydrateMOCProgress(c.Context(), h, articles)
 		hydrateReadingTime(articles)
 		return c.JSON(articles)
 	})

--- a/backend/internal/handlers/status.go
+++ b/backend/internal/handlers/status.go
@@ -64,6 +64,18 @@ func hydrateReadingStatus(ctx context.Context, h *HandlerContext, articles []rep
 	}
 }
 
+// hydrateMOCProgress fills the collection rollup on Map of Content hubs. Used on
+// the Vault-less path; the Vault hydrates its own results. A failure degrades to
+// no indicator rather than failing the list.
+func hydrateMOCProgress(ctx context.Context, h *HandlerContext, articles []repository.GormArticle) {
+	if len(articles) == 0 || h.DB == nil {
+		return
+	}
+	if err := repository.HydrateMOCProgress(ctx, h.DB, articles); err != nil && h.Logger != nil {
+		h.Logger.Error("Failed to load MOC progress", zap.Error(err))
+	}
+}
+
 // articleExists reports whether an article is present and not soft-deleted, so
 // progress cannot be recorded against a missing id.
 func articleExists(h *HandlerContext, id int64) (bool, error) {

--- a/backend/internal/repository/gorm_repo.go
+++ b/backend/internal/repository/gorm_repo.go
@@ -78,16 +78,17 @@ func extractCandidateKeywords(title, body string, maxKeywords int) []string {
 
 type GormArticle struct {
 	gorm.Model
-	ID              int64   `gorm:"primaryKey"`
-	Article         string  `json:"article"`
-	Image           string  `json:"image"`
-	Title           string  `json:"title"`
-	Tags            string  `json:"tags"`
-	IsArchived      bool    `gorm:"default:false;index" json:"is_archived"`
-	WordCount       int     `gorm:"default:0" json:"word_count"`
-	ReadingStatus   string  `gorm:"-" json:"reading_status"`
-	ReadingProgress float64 `gorm:"-" json:"reading_progress"`
-	ReadingTime     string  `gorm:"-" json:"reading_time"`
+	ID              int64        `gorm:"primaryKey"`
+	Article         string       `json:"article"`
+	Image           string       `json:"image"`
+	Title           string       `json:"title"`
+	Tags            string       `json:"tags"`
+	IsArchived      bool         `gorm:"default:false;index" json:"is_archived"`
+	WordCount       int          `gorm:"default:0" json:"word_count"`
+	ReadingStatus   string       `gorm:"-" json:"reading_status"`
+	ReadingProgress float64      `gorm:"-" json:"reading_progress"`
+	ReadingTime     string       `gorm:"-" json:"reading_time"`
+	MOCProgress     *MOCProgress `gorm:"-" json:"moc_progress,omitempty"`
 }
 
 func (GormArticle) TableName() string {

--- a/backend/internal/repository/moc_progress.go
+++ b/backend/internal/repository/moc_progress.go
@@ -1,0 +1,134 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// MOCProgress is the reading rollup for a Map of Content: how many of its
+// member notes are finished and how many are underway. Not-started is the
+// remainder, so callers derive it rather than trusting a third counter.
+//
+// A MOC never owns an article_statuses row of its own — scroll progress through
+// a generated index is meaningless — so this is the only progress a hub has.
+type MOCProgress struct {
+	Total      int `json:"total"`
+	Read       int `json:"read"`
+	InProgress int `json:"in_progress"`
+}
+
+// mocMemberRow is one MOC-to-member edge joined to that member's reading state.
+// StatusArticleID is zero when the member has no article_statuses row, which is
+// how "never opened" reaches us through the LEFT JOIN.
+type mocMemberRow struct {
+	SourceID        int64
+	TargetID        int64
+	StatusArticleID int64
+	StatusKey       string
+	Progress        float64
+	IsManual        bool
+}
+
+// Membership is the MOC's outbound links: the Librarian writes an article_links
+// row per curated entry in the same transaction as the markdown wikilink, so
+// source_id -> target_id is the collection.
+const mocMemberQuery = `
+SELECT l.source_id AS source_id,
+       l.target_id AS target_id,
+       COALESCE(s.article_id, 0) AS status_article_id,
+       COALESCE(s.status_key, '') AS status_key,
+       COALESCE(s.progress, 0) AS progress,
+       COALESCE(s.is_manual, 0) AS is_manual
+FROM article_links l
+JOIN articles a ON a.id = l.target_id
+LEFT JOIN article_statuses s ON s.article_id = a.id
+WHERE l.source_id IN ?
+  AND a.deleted_at IS NULL
+  AND l.target_id <> l.source_id
+`
+
+// GetMOCProgress rolls up member reading state for the given MOCs in one query,
+// keyed by MOC id. MOCs with no resolvable members are absent from the map
+// rather than present with a zero Total, so callers can tell "empty hub" from
+// "hub whose members are all unread".
+func GetMOCProgress(ctx context.Context, db *gorm.DB, mocIDs []int64) (map[int64]MOCProgress, error) {
+	result := make(map[int64]MOCProgress, len(mocIDs))
+	if len(mocIDs) == 0 {
+		return result, nil
+	}
+
+	var rows []mocMemberRow
+	if err := db.WithContext(ctx).Raw(mocMemberQuery, mocIDs).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	// article_links has no unique constraint, so the same member can appear
+	// twice for one MOC. Count each target once.
+	seen := make(map[[2]int64]struct{}, len(rows))
+	for _, row := range rows {
+		key := [2]int64{row.SourceID, row.TargetID}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		progress := result[row.SourceID]
+		progress.Total++
+
+		// DeriveStatusKey owns the manual-override and FinishedThreshold rules;
+		// comparing Progress here would quietly diverge from the article cards.
+		var status *GormArticleStatus
+		if row.StatusArticleID != 0 {
+			status = &GormArticleStatus{
+				ArticleID: row.StatusArticleID,
+				StatusKey: row.StatusKey,
+				Progress:  row.Progress,
+				IsManual:  row.IsManual,
+			}
+		}
+		switch DeriveStatusKey(status) {
+		case StatusFinished:
+			progress.Read++
+		case StatusNotFinished:
+			progress.InProgress++
+		}
+
+		result[row.SourceID] = progress
+	}
+
+	return result, nil
+}
+
+// HydrateMOCProgress fills MOCProgress on every MOC in articles. Non-MOCs and
+// member-less MOCs are left nil, which is what keeps them off the wire and out
+// of the UI.
+func HydrateMOCProgress(ctx context.Context, db *gorm.DB, articles []GormArticle) error {
+	if len(articles) == 0 || db == nil {
+		return nil
+	}
+
+	var mocIDs []int64
+	for _, article := range articles {
+		if IsMOCArticle(article.Title, article.Tags) {
+			mocIDs = append(mocIDs, article.ID)
+		}
+	}
+	if len(mocIDs) == 0 {
+		return nil
+	}
+
+	progressByMOC, err := GetMOCProgress(ctx, db, mocIDs)
+	if err != nil {
+		return err
+	}
+
+	for i := range articles {
+		progress, ok := progressByMOC[articles[i].ID]
+		if !ok || progress.Total == 0 {
+			continue
+		}
+		articles[i].MOCProgress = &progress
+	}
+	return nil
+}

--- a/backend/internal/repository/moc_progress_test.go
+++ b/backend/internal/repository/moc_progress_test.go
@@ -1,0 +1,197 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// seedMOCVault creates one MOC and the given member articles, linking each to
+// the MOC. It returns the MOC's id.
+func seedMOCVault(t *testing.T, db *gorm.DB, mocID int64, memberIDs ...int64) int64 {
+	t.Helper()
+
+	if err := db.Create(&GormArticle{ID: mocID, Title: "MOC - Kubernetes", Tags: "k8s", Article: "/articles/Kubernetes/MOC - Kubernetes.md"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range memberIDs {
+		if err := db.Create(&GormArticle{ID: id, Title: "Member", Article: "/articles/Kubernetes/Member.md"}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec("INSERT INTO article_links (source_id, target_id) VALUES (?, ?)", mocID, id).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	return mocID
+}
+
+func setStatus(t *testing.T, db *gorm.DB, articleID int64, progress float64, manual bool, key string) {
+	t.Helper()
+	status := GormArticleStatus{
+		ArticleID:  articleID,
+		Progress:   progress,
+		IsManual:   manual,
+		StatusKey:  key,
+		OpenedAt:   time.Now(),
+		LastReadAt: time.Now(),
+	}
+	if err := db.Create(&status).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetMOCProgressMixedRollup(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+	moc := seedMOCVault(t, db, 100, 101, 102, 103, 104)
+
+	setStatus(t, db, 101, 100, false, StatusFinished) // finished by progress
+	setStatus(t, db, 102, 42, false, StatusNotFinished)
+	setStatus(t, db, 103, 12, false, StatusNotFinished)
+	// 104 has no row at all -> never opened
+
+	got, err := GetMOCProgress(context.Background(), db, []int64{moc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := MOCProgress{Total: 4, Read: 1, InProgress: 2}
+	if got[moc] != want {
+		t.Fatalf("got %+v, want %+v", got[moc], want)
+	}
+}
+
+// A member marked finished by hand counts as read even though its recorded
+// progress is nowhere near the threshold.
+func TestGetMOCProgressHonorsManualOverride(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+	moc := seedMOCVault(t, db, 100, 101, 102)
+
+	setStatus(t, db, 101, 3, true, StatusFinished)
+	setStatus(t, db, 102, 99, true, StatusNotFinished) // manual override downward
+
+	got, err := GetMOCProgress(context.Background(), db, []int64{moc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := MOCProgress{Total: 2, Read: 1, InProgress: 1}
+	if got[moc] != want {
+		t.Fatalf("got %+v, want %+v", got[moc], want)
+	}
+}
+
+func TestGetMOCProgressExcludesDeletedMembers(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+	moc := seedMOCVault(t, db, 100, 101, 102)
+
+	if err := db.Delete(&GormArticle{}, 102).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetMOCProgress(context.Background(), db, []int64{moc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got[moc].Total != 1 {
+		t.Fatalf("got Total %d, want 1", got[moc].Total)
+	}
+}
+
+// article_links has no unique constraint, so a duplicated edge must not inflate
+// the member count.
+func TestGetMOCProgressDedupesDuplicateLinks(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+	moc := seedMOCVault(t, db, 100, 101)
+
+	if err := db.Exec("INSERT INTO article_links (source_id, target_id) VALUES (?, ?)", moc, 101).Error; err != nil {
+		t.Fatal(err)
+	}
+	setStatus(t, db, 101, 100, false, StatusFinished)
+
+	got, err := GetMOCProgress(context.Background(), db, []int64{moc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := MOCProgress{Total: 1, Read: 1}
+	if got[moc] != want {
+		t.Fatalf("got %+v, want %+v", got[moc], want)
+	}
+}
+
+// A self-link would otherwise make a hub count itself as one of its own notes.
+func TestGetMOCProgressIgnoresSelfLink(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+	moc := seedMOCVault(t, db, 100, 101)
+
+	if err := db.Exec("INSERT INTO article_links (source_id, target_id) VALUES (?, ?)", moc, moc).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetMOCProgress(context.Background(), db, []int64{moc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got[moc].Total != 1 {
+		t.Fatalf("got Total %d, want 1", got[moc].Total)
+	}
+}
+
+func TestGetMOCProgressEmptyAndMemberless(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+
+	got, err := GetMOCProgress(context.Background(), db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d entries for no ids, want 0", len(got))
+	}
+
+	moc := seedMOCVault(t, db, 100)
+	got, err = GetMOCProgress(context.Background(), db, []int64{moc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got[moc]; ok {
+		t.Fatalf("member-less MOC should be absent from the map, got %+v", got[moc])
+	}
+}
+
+func TestHydrateMOCProgress(t *testing.T) {
+	_, db := setupStatusTestRepo(t)
+	seedMOCVault(t, db, 100, 101, 102)
+	setStatus(t, db, 101, 100, false, StatusFinished)
+
+	// A second hub with no members, and a plain note, must both stay nil.
+	if err := db.Create(&GormArticle{ID: 200, Title: "MOC - Empty", Article: "/articles/Empty/MOC - Empty.md"}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	articles := []GormArticle{
+		{ID: 100, Title: "MOC - Kubernetes", Tags: "k8s"},
+		{ID: 200, Title: "MOC - Empty"},
+		{ID: 101, Title: "Member"},
+	}
+	if err := HydrateMOCProgress(context.Background(), db, articles); err != nil {
+		t.Fatal(err)
+	}
+
+	if articles[0].MOCProgress == nil {
+		t.Fatal("hub with members should be hydrated")
+	}
+	want := MOCProgress{Total: 2, Read: 1}
+	if *articles[0].MOCProgress != want {
+		t.Fatalf("got %+v, want %+v", *articles[0].MOCProgress, want)
+	}
+	if articles[1].MOCProgress != nil {
+		t.Fatalf("member-less hub should stay nil, got %+v", *articles[1].MOCProgress)
+	}
+	if articles[2].MOCProgress != nil {
+		t.Fatalf("plain note should stay nil, got %+v", *articles[2].MOCProgress)
+	}
+}

--- a/backend/internal/vault/vault.go
+++ b/backend/internal/vault/vault.go
@@ -390,6 +390,9 @@ func (v *DefaultVault) ListArticles(ctx context.Context, filter ArticleFilter) (
 	if err := v.hydrateReadingStatus(ctx, articles); err != nil {
 		v.logger.Error("Failed to hydrate reading status", zap.Error(err))
 	}
+	if err := repository.HydrateMOCProgress(ctx, v.db, articles); err != nil {
+		v.logger.Error("Failed to hydrate MOC progress", zap.Error(err))
+	}
 	v.hydrateReadingTime(articles)
 
 	return articles, nil

--- a/frontend/src/components/Article.vue
+++ b/frontend/src/components/Article.vue
@@ -11,6 +11,7 @@ import ArticleHoverPreview from './ArticleHoverPreview.vue'
 import ArticleStatusRing from './ArticleStatusRing.vue'
 import MocProgressLabel from './MocProgressLabel.vue'
 import type { MocProgress } from '../utils/moc'
+import { resolveWikilinkTarget } from '../utils/wikilink'
 import GraphZoomControls from './GraphZoomControls.vue'
 import { useGraphZoom } from '../composables/useGraphZoom'
 import emitter from '../event-bus'
@@ -41,11 +42,7 @@ const allArticles = ref<ArticleData[]>([])
 
 const currentArticle = computed(() => {
   const param = String(route.params.id || '').replace(/\.md$/, '').trim()
-  return allArticles.value.find(a => 
-    String(a.ID) === param ||
-    a.title.trim().toLowerCase() === param.toLowerCase() ||
-    a.article.replace(/^\/?articles\//, '').replace(/\.md$/, '').trim().toLowerCase() === param.toLowerCase()
-  ) || null
+  return resolveWikilinkTarget(allArticles.value, param) || null
 })
 
 const getArticleId = () => {
@@ -958,12 +955,9 @@ const loadContent = async () => {
     const parsedRaw = raw.replace(/\[\[([^[\]\n]+?)\]\]/g, (_, p1) => {
       const fullText = String(p1 || '').trim()
       
-      // 1. First check if the full un-split string matches an article title (e.g. "Title | Site Name")
-      const matchFull = allArticles.value.find(a => 
-        a.title.trim().toLowerCase() === fullText.toLowerCase() ||
-        String(a.ID) === fullText ||
-        a.article.replace(/^\/?articles\//, '').replace(/\.md$/, '').trim().toLowerCase() === fullText.toLowerCase()
-      )
+      // 1. First check if the full un-split string matches an article (e.g. a
+      //    title that genuinely contains a pipe, like "Title | Site Name")
+      const matchFull = resolveWikilinkTarget(allArticles.value, fullText)
 
       if (matchFull) {
         return `<a href="/articles/${matchFull.ID}" data-article-id="${matchFull.ID}" class="wikilink font-semibold text-emerald-600 dark:text-emerald-400 no-underline hover:underline hover:text-emerald-700 dark:hover:text-emerald-300 transition-colors bg-emerald-50/50 dark:bg-emerald-900/20 px-1.5 py-0.5 rounded-md border border-emerald-100 dark:border-emerald-800/50 cursor-pointer">${matchFull.title}</a>`
@@ -974,11 +968,7 @@ const loadContent = async () => {
       const targetTitle = parts[0].trim()
       const display = parts.length > 1 ? parts.slice(1).join('|').trim() : targetTitle
       
-      const targetArticle = allArticles.value.find(a => 
-        a.title.trim().toLowerCase() === targetTitle.toLowerCase() ||
-        String(a.ID) === targetTitle ||
-        a.article.replace(/^\/?articles\//, '').replace(/\.md$/, '').trim().toLowerCase() === targetTitle.toLowerCase()
-      )
+      const targetArticle = resolveWikilinkTarget(allArticles.value, targetTitle)
 
       if (targetArticle) {
         return `<a href="/articles/${targetArticle.ID}" data-article-id="${targetArticle.ID}" class="wikilink font-semibold text-emerald-600 dark:text-emerald-400 no-underline hover:underline hover:text-emerald-700 dark:hover:text-emerald-300 transition-colors bg-emerald-50/50 dark:bg-emerald-900/20 px-1.5 py-0.5 rounded-md border border-emerald-100 dark:border-emerald-800/50 cursor-pointer">${display}</a>`

--- a/frontend/src/components/Article.vue
+++ b/frontend/src/components/Article.vue
@@ -9,6 +9,8 @@ import 'highlight.js/styles/github-dark.css'
 import { Network } from 'vis-network'
 import ArticleHoverPreview from './ArticleHoverPreview.vue'
 import ArticleStatusRing from './ArticleStatusRing.vue'
+import MocProgressLabel from './MocProgressLabel.vue'
+import type { MocProgress } from '../utils/moc'
 import GraphZoomControls from './GraphZoomControls.vue'
 import { useGraphZoom } from '../composables/useGraphZoom'
 import emitter from '../event-bus'
@@ -32,6 +34,7 @@ interface ArticleData {
   reading_progress?: number
   reading_time?: string
   word_count?: number
+  moc_progress?: MocProgress | null
 }
 
 const allArticles = ref<ArticleData[]>([])
@@ -1206,9 +1209,24 @@ onBeforeUnmount(() => {
         </div>
 
         <div class="flex items-center gap-1.5 sm:gap-2">
+          <!--
+            Collection Progress: a hub has no reading state of its own, so it
+            reports how much of what it indexes is read. Read-only — there is no
+            Finish button, because finishing a hub means reading its notes.
+          -->
+          <div
+            v-if="isMOC && currentArticle?.moc_progress"
+            class="flex items-center gap-1 px-2.5 py-1 rounded-xl bg-gray-100/80 dark:bg-white/[0.04] border border-gray-200/50 dark:border-white/[0.04]"
+          >
+            <MocProgressLabel
+              :progress="currentArticle?.moc_progress"
+              variant="reader"
+            />
+          </div>
+
           <!-- Reading Status: same ring the vault shows, live as you scroll -->
           <div
-            v-if="!isMOC"
+            v-else-if="!isMOC"
             class="flex items-center gap-1 pl-2 pr-1 py-1 rounded-xl bg-gray-100/80 dark:bg-white/[0.04] border border-gray-200/50 dark:border-white/[0.04]"
           >
             <ArticleStatusRing

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -5,7 +5,8 @@ import emitter from '../event-bus.ts'
 import BookmarkIcon from '../assets/book.svg'
 import { settings, setViewMode as saveGlobalViewMode } from '../store/settings'
 import ArticleProgressLabel from './ArticleProgressLabel.vue'
-import { isMoc } from '../utils/moc'
+import MocProgressLabel from './MocProgressLabel.vue'
+import { isMoc, type MocProgress } from '../utils/moc'
 
 interface Article {
   ID: number
@@ -18,6 +19,7 @@ interface Article {
   reading_progress?: number
   reading_time?: string
   word_count?: number
+  moc_progress?: MocProgress | null
 }
 
 defineProps<{ msg?: string }>()
@@ -134,6 +136,12 @@ function getReadingTime(articleOrText?: Article | string | null): string {
 function isMocArticle(article: Article): boolean {
   if (!article) return false
   return isMoc(article.title, article.parsedTags)
+}
+
+// A hub with no resolvable members shows no indicator at all, so the pill that
+// floats over a cover image must collapse with it rather than sit there empty.
+function hasReadingIndicator(article: Article): boolean {
+  return !isMocArticle(article) || !!article.moc_progress
 }
 
 function getDomain(article: Article): string {
@@ -645,10 +653,16 @@ const secondaryArticles = computed(() => {
                   <span>{{ formatDate(leadArticle.ID) || 'Recent' }}</span>
                   <span>•</span>
                   <span>{{ getReadingTime(leadArticle) }}</span>
-                  <span>&bull;</span>
-                  <ArticleProgressLabel
+                  <span v-if="hasReadingIndicator(leadArticle)">&bull;</span>
+                  <MocProgressLabel
+                    v-if="isMocArticle(leadArticle)"
                     variant="meta"
-                    :status="isMocArticle(leadArticle) ? 'not_started' : leadArticle.reading_status"
+                    :progress="leadArticle.moc_progress"
+                  />
+                  <ArticleProgressLabel
+                    v-else
+                    variant="meta"
+                    :status="leadArticle.reading_status"
                     :progress="leadArticle.reading_progress"
                   />
                 </div>
@@ -791,9 +805,15 @@ const secondaryArticles = computed(() => {
                   <span class="w-1 h-1 rounded-full bg-emerald-400"></span>
                   {{ getDomain(article) }}
                 </span>
-                <ArticleProgressLabel
+                <MocProgressLabel
+                  v-if="isMocArticle(article)"
                   variant="overlay"
-                  :status="isMocArticle(article) ? 'not_started' : article.reading_status"
+                  :progress="article.moc_progress"
+                />
+                <ArticleProgressLabel
+                  v-else
+                  variant="overlay"
+                  :status="article.reading_status"
                   :progress="article.reading_progress"
                 />
               </div>
@@ -813,10 +833,16 @@ const secondaryArticles = computed(() => {
                 <span class="w-1 h-1 rounded-full bg-emerald-400"></span>
                 {{ getDomain(article) }}
               </span>
-              <span class="px-2.5 py-0.5 rounded-full bg-black/60 backdrop-blur-md border border-white/15 shadow-xs inline-flex items-center">
-                <ArticleProgressLabel
+              <span v-if="hasReadingIndicator(article)" class="px-2.5 py-0.5 rounded-full bg-black/60 backdrop-blur-md border border-white/15 shadow-xs inline-flex items-center">
+                <MocProgressLabel
+                  v-if="isMocArticle(article)"
                   variant="overlay"
-                  :status="isMocArticle(article) ? 'not_started' : article.reading_status"
+                  :progress="article.moc_progress"
+                />
+                <ArticleProgressLabel
+                  v-else
+                  variant="overlay"
+                  :status="article.reading_status"
                   :progress="article.reading_progress"
                 />
               </span>
@@ -989,13 +1015,6 @@ const secondaryArticles = computed(() => {
                   {{ getReadingTime(article) }}
                 </span>
 
-                <!-- Reading Status -->
-                <ArticleProgressLabel
-                  variant="meta"
-                  :status="isMocArticle(article) ? 'not_started' : article.reading_status"
-                  :progress="article.reading_progress"
-                />
-
                 <!-- MOC Badge -->
                 <span
                   v-if="isMocArticle(article)"
@@ -1003,6 +1022,19 @@ const secondaryArticles = computed(() => {
                 >
                   ★ MOC
                 </span>
+
+                <!-- Reading Status -->
+                <MocProgressLabel
+                  v-if="isMocArticle(article)"
+                  variant="meta"
+                  :progress="article.moc_progress"
+                />
+                <ArticleProgressLabel
+                  v-else
+                  variant="meta"
+                  :status="article.reading_status"
+                  :progress="article.reading_progress"
+                />
 
                 <!-- Tags -->
                 <button

--- a/frontend/src/components/MocProgressLabel.vue
+++ b/frontend/src/components/MocProgressLabel.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import MocProgressRing from './MocProgressRing.vue'
+import type { MocProgress } from '../utils/moc'
+
+/**
+ * The reading indicator for a Map of Content, standing where
+ * ArticleProgressLabel stands on a plain note.
+ *
+ * A hub is a collection, not reading material — it never accumulates a status
+ * row of its own — so it reports how much of its collection is read rather
+ * than how far you scrolled through the index:
+ *
+ *   nothing read   →  ◌ 0/10 notes    (neutral)
+ *   partly read    →  ◕ 4/10 notes    (neutral, green + blue bands)
+ *   fully read     →  ● 10/10 notes   (green)
+ *
+ * "notes", not "read": the same meta row already carries "5 min read" a few
+ * characters away, and one row should not use one word for a duration and a
+ * count of finished things. The ring and the tooltip carry "read".
+ *
+ * Renders nothing at all when the hub has no resolvable members: the ★ MOC
+ * badge already identifies the card, and an empty 0/0 ring would only be noise.
+ * That check living here is what keeps every call site a plain v-if on isMoc.
+ */
+const props = withDefaults(defineProps<{
+  progress?: MocProgress | null
+  /**
+   * 'overlay' sits on the dark translucent pill over a cover image, which is
+   * dark in both themes; 'meta' sits in a normal text row; 'reader' is the
+   * sticky reader toolbar, where there is room for a larger glyph and the
+   * ★ MOC HUB badge has scrolled out of view.
+   */
+  variant?: 'overlay' | 'meta' | 'reader'
+  /** Override the glyph size; defaults to the variant's optical match. */
+  size?: number
+}>(), {
+  variant: 'meta',
+})
+
+const total = computed(() => Number(props.progress?.total) || 0)
+const read = computed(() => Math.min(Number(props.progress?.read) || 0, total.value))
+const inProgress = computed(() =>
+  Math.min(Number(props.progress?.in_progress) || 0, total.value - read.value)
+)
+
+const hasMembers = computed(() => total.value > 0)
+const isComplete = computed(() => hasMembers.value && read.value === total.value)
+
+// Full class strings, never interpolated: Tailwind only generates literals.
+//
+// Two tones, not the article label's three: no blue. On an article, blue is the
+// state — "60%" in gray would say nothing. Here the state is already spelled out
+// as a fraction, and blue would fight the ring rather than agree with it: a hub
+// with 1 read and 0 in progress has a green-only ring, and blue text beside it
+// states a second, contradictory thing. The extreme is 0 read / 1 in progress —
+// a saturated "active" chip whose number is zero. Blue stays in the ring, where
+// it sits against green at proportional length and can be compared.
+const TONES = {
+  overlay: {
+    idle: 'text-white/75',
+    complete: 'text-emerald-300',
+  },
+  meta: {
+    idle: 'text-gray-500 dark:text-gray-400',
+    complete: 'text-emerald-600 dark:text-emerald-400',
+  },
+  reader: {
+    idle: 'text-gray-600 dark:text-gray-300',
+    complete: 'text-emerald-600 dark:text-emerald-400',
+  },
+} as const
+
+// Text scales with the glyph. An 11px mono cap height is ~7.7px, so pairing it
+// with an 18px ring leaves a small number hanging off a big circle.
+const SIZES = {
+  overlay: 'text-[10px]',
+  meta: 'text-[11px]',
+  reader: 'text-xs',
+} as const
+
+// A notch above ArticleProgressLabel's 11/12 on purpose: this ring resolves
+// tenths of a turn, so it needs the extra pixels the article ring does not.
+const GLYPH_SIZES = { overlay: 13, meta: 14, reader: 18 } as const
+
+const glyphSize = computed(() => props.size ?? GLYPH_SIZES[props.variant])
+
+// The ring has two palettes, not three: 'reader' sits on a normal light/dark
+// surface, so it takes the same strokes as 'meta'.
+const ringVariant = computed(() => (props.variant === 'overlay' ? 'overlay' : 'meta'))
+
+const toneClass = computed(() => {
+  const key = isComplete.value ? 'complete' : 'idle'
+  return [TONES[props.variant][key], SIZES[props.variant]]
+})
+
+// Doubles as the accessible name: the bands live inside an aria-hidden <svg>,
+// and "4/10" alone does not say what was counted.
+const title = computed(() => {
+  const noun = total.value === 1 ? 'note' : 'notes'
+  if (isComplete.value) return `All ${total.value} ${noun} read`
+  if (inProgress.value > 0) {
+    return `${read.value} of ${total.value} ${noun} read, ${inProgress.value} in progress`
+  }
+  return `${read.value} of ${total.value} ${noun} read`
+})
+</script>
+
+<template>
+  <span
+    v-if="hasMembers"
+    class="inline-flex items-center gap-1 shrink-0 whitespace-nowrap font-mono font-medium"
+    :class="toneClass"
+    role="img"
+    :aria-label="title"
+    :title="title"
+  >
+    <MocProgressRing :progress="progress" :variant="ringVariant" :size="glyphSize" />
+    <!-- The reader spells the unit out: its ★ MOC HUB badge scrolls away. -->
+    <span v-if="variant === 'reader'">{{ read }} of {{ total }} notes read</span>
+    <span v-else>{{ read }}/{{ total }} notes</span>
+  </span>
+</template>

--- a/frontend/src/components/MocProgressRing.vue
+++ b/frontend/src/components/MocProgressRing.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { mocRingSegments, type MocProgress } from '../utils/moc'
+
+/**
+ * The segmented ring for a Map of Content's collection.
+ *
+ * A sibling of ArticleStatusRing rather than a mode on it: this ring shows two
+ * colors at once, so it cannot use that component's single inherited stroke,
+ * and its arcs are counts of notes rather than one document's scroll position.
+ * Geometry is copied deliberately — same radius, box and stroke width — so the
+ * two rings sit at identical optical weight in the same card row.
+ */
+const props = withDefaults(defineProps<{
+  progress?: MocProgress | null
+  /**
+   * 'overlay' sits on the dark translucent pill over a cover image, which is
+   * dark in both themes; 'meta' sits in a normal text row and needs a
+   * light/dark pair.
+   */
+  variant?: 'overlay' | 'meta'
+  size?: number
+}>(), {
+  variant: 'meta',
+  size: 14,
+})
+
+// Thicker and slightly tighter than ArticleStatusRing's 9/2.5. A hub's ring has
+// to resolve a tenth of a turn — 36 degrees — where the article ring only ever
+// shows one arc whose value is restated verbatim in the number beside it. At
+// r=9/stroke=2.5 rendered at 12px, that tenth is a 2.8px speck on a 1.25px
+// stroke and the ring reads as empty. 8.25 + 3.5/2 = 10 keeps the extent inside
+// the 24-unit box.
+const RADIUS = 8.25
+const STROKE = 3.5
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+const segments = computed(() => mocRingSegments(props.progress))
+
+const startedOffset = computed(() => CIRCUMFERENCE * (1 - segments.value.started))
+const readOffset = computed(() => CIRCUMFERENCE * (1 - segments.value.read))
+
+// Full class strings, never interpolated: Tailwind only generates literals.
+//
+// The track is not decorative — it encodes the unread remainder, and on a hub
+// whose arcs are both tiny it is the only thing drawn. gray-300 on a white card
+// is ~1.5:1, well under the 3:1 non-text floor, so it goes a step darker.
+const TONES = {
+  overlay: {
+    track: 'stroke-white/40',
+    started: 'stroke-blue-300',
+    read: 'stroke-emerald-300',
+  },
+  meta: {
+    track: 'stroke-gray-400 dark:stroke-white/30',
+    started: 'stroke-blue-500 dark:stroke-blue-400',
+    read: 'stroke-emerald-500 dark:stroke-emerald-400',
+  },
+} as const
+
+const tone = computed(() => TONES[props.variant])
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    class="shrink-0 -rotate-90"
+    aria-hidden="true"
+  >
+    <!-- Track: the not-started remainder, left exposed by the arcs above it -->
+    <circle cx="12" cy="12" :r="RADIUS" :stroke-width="STROKE" :class="tone.track" />
+    <!--
+      Started and read are nested arcs from the same origin, painted in that
+      order. Butt caps, not the round caps ArticleStatusRing uses: a round cap
+      would overhang the boundary and let green bleed past its own count.
+
+      No transition, unlike ArticleStatusRing: that ring fills live as you
+      scroll your own reading, while a hub's counts only ever change between
+      page loads. Animating them would sweep arcs across a grid on re-render
+      for no reason a reader could connect to an action.
+    -->
+    <circle
+      v-if="segments.started > 0"
+      cx="12"
+      cy="12"
+      :r="RADIUS"
+      :stroke-width="STROKE"
+      stroke-linecap="butt"
+      :stroke-dasharray="CIRCUMFERENCE"
+      :stroke-dashoffset="startedOffset"
+      :class="tone.started"
+    />
+    <circle
+      v-if="segments.read > 0"
+      cx="12"
+      cy="12"
+      :r="RADIUS"
+      :stroke-width="STROKE"
+      stroke-linecap="butt"
+      :stroke-dasharray="CIRCUMFERENCE"
+      :stroke-dashoffset="readOffset"
+      :class="tone.read"
+    />
+  </svg>
+</template>

--- a/frontend/src/utils/moc.test.ts
+++ b/frontend/src/utils/moc.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'bun:test';
+import { isMoc, mocRingSegments } from './moc';
+
+describe('isMoc', () => {
+  it('detects hubs by the surviving title prefix', () => {
+    expect(isMoc('MOC - Kubernetes', 'k8s')).toBe(true);
+    expect(isMoc('moc: Azure', '')).toBe(true);
+    expect(isMoc('MOC', null)).toBe(true);
+  });
+
+  it('detects freshly-created hubs by tag', () => {
+    expect(isMoc('Kubernetes Overview', 'moc, k8s')).toBe(true);
+    expect(isMoc('Kubernetes Overview', ['moc', 'k8s'])).toBe(true);
+  });
+
+  it('leaves plain notes alone', () => {
+    expect(isMoc('Mocking in Go', 'testing')).toBe(false);
+    expect(isMoc('Pods', undefined)).toBe(false);
+  });
+});
+
+describe('mocRingSegments', () => {
+  it('nests the read arc inside the started arc', () => {
+    const { read, started } = mocRingSegments({ total: 10, read: 4, in_progress: 3 });
+    expect(read).toBeCloseTo(0.4);
+    expect(started).toBeCloseTo(0.7);
+  });
+
+  it('fills the ring when every note is read', () => {
+    expect(mocRingSegments({ total: 10, read: 10, in_progress: 0 })).toEqual({ read: 1, started: 1 });
+  });
+
+  it('draws only the blue band when nothing is finished', () => {
+    const { read, started } = mocRingSegments({ total: 10, read: 0, in_progress: 1 });
+    expect(read).toBe(0);
+    expect(started).toBeCloseTo(0.1);
+  });
+
+  it('floors a small nonzero count to a visible arc', () => {
+    // A true 1/20 is a hairline that reads as an empty ring, contradicting the
+    // "1/20" in the label beside it.
+    const { read, started } = mocRingSegments({ total: 20, read: 1, in_progress: 0 });
+    expect(read).toBeCloseTo(0.085);
+    expect(started).toBeCloseTo(0.085);
+  });
+
+  it('never floors a zero count into a band', () => {
+    expect(mocRingSegments({ total: 20, read: 0, in_progress: 0 })).toEqual({ read: 0, started: 0 });
+  });
+
+  it('shows a blue band past the green one when both counts are sub-floor', () => {
+    const { read, started } = mocRingSegments({ total: 40, read: 1, in_progress: 1 });
+    expect(read).toBeCloseTo(0.085);
+    expect(started).toBeCloseTo(0.17);
+    expect(started).toBeGreaterThan(read);
+  });
+
+  it('adds no blue band when nothing is in progress', () => {
+    const { read, started } = mocRingSegments({ total: 40, read: 1, in_progress: 0 });
+    expect(read).toEqual(started);
+  });
+
+  it('never exceeds a full turn', () => {
+    const { read, started } = mocRingSegments({ total: 1, read: 0, in_progress: 1 });
+    expect(started).toBe(1);
+    expect(read).toBe(0);
+  });
+
+  it('leaves counts above the floor untouched', () => {
+    const { read, started } = mocRingSegments({ total: 10, read: 4, in_progress: 3 });
+    expect(read).toBeCloseTo(0.4);
+    expect(started).toBeCloseTo(0.7);
+  });
+
+  it('returns an empty ring for a member-less hub', () => {
+    expect(mocRingSegments({ total: 0, read: 0, in_progress: 0 })).toEqual({ read: 0, started: 0 });
+  });
+
+  it('returns an empty ring for a missing rollup', () => {
+    expect(mocRingSegments(null)).toEqual({ read: 0, started: 0 });
+    expect(mocRingSegments(undefined)).toEqual({ read: 0, started: 0 });
+  });
+
+  it('clamps counts that overrun the total', () => {
+    expect(mocRingSegments({ total: 3, read: 9, in_progress: 9 })).toEqual({ read: 1, started: 1 });
+    expect(mocRingSegments({ total: 4, read: 3, in_progress: 3 })).toEqual({ read: 0.75, started: 1 });
+  });
+
+  it('survives negative and non-finite counts', () => {
+    expect(mocRingSegments({ total: 4, read: -2, in_progress: NaN })).toEqual({ read: 0, started: 0 });
+    expect(mocRingSegments({ total: NaN, read: 1, in_progress: 1 })).toEqual({ read: 0, started: 0 });
+  });
+});

--- a/frontend/src/utils/moc.ts
+++ b/frontend/src/utils/moc.ts
@@ -31,3 +31,60 @@ function hasMocTag(tags: string | string[] | undefined | null): boolean {
 export function isMoc(title: string, tags: string | string[] | undefined | null): boolean {
   return hasMocTag(tags) || hasMocTitle(title)
 }
+
+/**
+ * A MOC's collection reading rollup, as sent by the API on hub articles only.
+ * Absent on plain notes and on hubs with no resolvable members.
+ */
+export interface MocProgress {
+  total: number
+  read: number
+  in_progress: number
+}
+
+/**
+ * The smallest arc a nonzero count is allowed to draw, as a fraction of the
+ * circumference — about 30 degrees.
+ *
+ * This deliberately overstates small counts. At the size these rings render, a
+ * true 1/20 is a hairline that disappears into the track, so the ring would say
+ * "none read" while the text beside it says "1/20" — a worse lie than rounding
+ * the arc up, and a contradiction the eye catches immediately. The exact counts
+ * are always in the label, so the arc is free to be the approximate one.
+ */
+const MIN_VISIBLE_ARC = 0.085
+
+/**
+ * Fractions of the ring for a MOC's collection, as two nested arcs drawn from
+ * the same origin rather than three abutting segments: `started` (read plus
+ * in-progress) is painted first and `read` over it, so the not-started
+ * remainder is just the exposed track. That nesting is what keeps the three
+ * bands seamless without any per-segment offset arithmetic.
+ *
+ * Clamped and ordered so `read <= started <= 1` whatever the server sent.
+ */
+export function mocRingSegments(p?: MocProgress | null): { read: number; started: number } {
+  const total = Number(p?.total)
+  if (!Number.isFinite(total) || total <= 0) return { read: 0, started: 0 }
+
+  const clamp = (n: number) => (Number.isFinite(n) ? Math.min(Math.max(n, 0), total) : 0)
+  const readCount = clamp(Number(p?.read))
+  const startedCount = Math.min(readCount + clamp(Number(p?.in_progress)), total)
+
+  // Zero stays zero — the floor makes small counts visible, it never invents a
+  // band for a count that does not exist.
+  const floor = (count: number) =>
+    count === 0 ? 0 : Math.max(count / total, MIN_VISIBLE_ARC)
+
+  const read = floor(readCount)
+
+  // The blue band is what shows *past* the green one, so it needs its own floor
+  // measured from the end of green — otherwise 1 read + 1 in progress out of 40
+  // floors both to the same arc and green hides blue completely.
+  const started =
+    startedCount > readCount
+      ? Math.max(floor(startedCount), read + MIN_VISIBLE_ARC)
+      : Math.max(floor(startedCount), read)
+
+  return { read: Math.min(read, 1), started: Math.min(started, 1) }
+}

--- a/frontend/src/utils/wikilink.test.ts
+++ b/frontend/src/utils/wikilink.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'bun:test';
+import { articleFileBase, articleRelativePath, resolveWikilinkTarget } from './wikilink';
+
+// Mirrors the real vault: notes live in topic folders, and three Azure notes
+// have a filename that differs from their title because SanitizeTitleFilename
+// stripped a "?" or truncated at 100 characters.
+const VAULT = [
+  { ID: 1, title: 'Pods', article: '/articles/Kubernetes/Pods.md' },
+  {
+    ID: 2,
+    title: 'What is Azure Pipelines? - Azure Pipelines',
+    article: '/articles/Microsoft Azure/What is Azure Pipelines - Azure Pipelines.md',
+  },
+  {
+    ID: 3,
+    title: 'How to Use the Azure Well-Architected Framework Documentation - Microsoft Azure Well-Architected Framework',
+    article: '/articles/Microsoft Azure/How to Use the Azure Well-Architected Framework Documentation - Microsoft Azure Well-Architected Fra.md',
+  },
+  { ID: 4, title: 'Loose Note', article: '/articles/Loose Note.md' },
+];
+
+describe('path helpers', () => {
+  it('strips the /articles/ prefix and .md suffix', () => {
+    expect(articleRelativePath('/articles/Kubernetes/Pods.md')).toBe('Kubernetes/Pods');
+  });
+
+  it('reduces a foldered path to its bare filename', () => {
+    expect(articleFileBase('/articles/Kubernetes/Pods.md')).toBe('Pods');
+    expect(articleFileBase('/articles/Loose Note.md')).toBe('Loose Note');
+    expect(articleFileBase('')).toBe('');
+  });
+});
+
+describe('resolveWikilinkTarget', () => {
+  it('resolves a target that equals the title', () => {
+    expect(resolveWikilinkTarget(VAULT, 'Pods')?.ID).toBe(1);
+  });
+
+  it('resolves a filename target whose title was sanitized', () => {
+    // This is the case that was rendering as dead text: the "?" is legal in a
+    // title but not in a filename, so the wikilink names the file.
+    expect(
+      resolveWikilinkTarget(VAULT, 'What is Azure Pipelines - Azure Pipelines')?.ID
+    ).toBe(2);
+  });
+
+  it('resolves a filename target that was truncated at 100 characters', () => {
+    expect(
+      resolveWikilinkTarget(
+        VAULT,
+        'How to Use the Azure Well-Architected Framework Documentation - Microsoft Azure Well-Architected Fra'
+      )?.ID
+    ).toBe(3);
+  });
+
+  it('resolves a folder-qualified path', () => {
+    expect(resolveWikilinkTarget(VAULT, 'Kubernetes/Pods')?.ID).toBe(1);
+  });
+
+  it('resolves a numeric id', () => {
+    expect(resolveWikilinkTarget(VAULT, '4')?.ID).toBe(4);
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(resolveWikilinkTarget(VAULT, '  pODS  ')?.ID).toBe(1);
+  });
+
+  it('prefers an exact title over another note whose filename collides', () => {
+    const ambiguous = [
+      { ID: 10, title: 'Overview', article: '/articles/Azure/Something Else.md' },
+      { ID: 11, title: 'Other', article: '/articles/Kubernetes/Overview.md' },
+    ];
+    expect(resolveWikilinkTarget(ambiguous, 'Overview')?.ID).toBe(10);
+  });
+
+  it('returns undefined for an unknown target', () => {
+    expect(resolveWikilinkTarget(VAULT, 'Nonexistent Note')).toBeUndefined();
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(resolveWikilinkTarget(VAULT, '')).toBeUndefined();
+    expect(resolveWikilinkTarget([], 'Pods')).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/wikilink.ts
+++ b/frontend/src/utils/wikilink.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolving a wikilink target to a vault article.
+ *
+ * A wikilink's target is a *filename*, not a title — `formatMOCArticleWikilink`
+ * in the Librarian writes `[[<file base>]]`, or `[[<file base>|<real title>]]`
+ * when the two differ. They differ whenever `SanitizeTitleFilename` had to
+ * change the title to make it a legal cross-platform filename: it replaces
+ * `? : * " < > | # ^ [ ] / \` with spaces and truncates at 100 characters. So
+ * "What is Azure Pipelines? - Azure Pipelines" lives in a file named
+ * "What is Azure Pipelines - Azure Pipelines.md".
+ *
+ * Matching on title alone therefore fails for exactly those notes, which is why
+ * resolution has to fall back to the filename.
+ */
+
+export interface ResolvableArticle {
+  ID: number
+  title: string
+  /** The vault-relative path, e.g. "/articles/Microsoft Azure/Pods.md". */
+  article: string
+}
+
+const norm = (value: string) => String(value || '').trim().toLowerCase()
+
+/** The vault-relative path with the leading "/articles/" and ".md" removed. */
+export function articleRelativePath(path: string): string {
+  return String(path || '')
+    .replace(/^\/?articles\//, '')
+    .replace(/\.md$/, '')
+    .trim()
+}
+
+/** Just the filename, without its topic folder or ".md". */
+export function articleFileBase(path: string): string {
+  const rel = articleRelativePath(path)
+  const slash = rel.lastIndexOf('/')
+  return slash === -1 ? rel : rel.slice(slash + 1)
+}
+
+/**
+ * Finds the article a wikilink target (or a route param) names.
+ *
+ * Tried in descending order of confidence, because the last test is ambiguous:
+ * two topic folders may hold files of the same name, so an exact title, id or
+ * full-path match must win before a bare filename is considered.
+ */
+export function resolveWikilinkTarget<T extends ResolvableArticle>(
+  articles: T[],
+  target: string
+): T | undefined {
+  const wanted = norm(target)
+  if (!wanted || !articles?.length) return undefined
+
+  return (
+    articles.find(a => norm(a.title) === wanted) ??
+    articles.find(a => String(a.ID) === target.trim()) ??
+    articles.find(a => norm(articleRelativePath(a.article)) === wanted) ??
+    articles.find(a => norm(articleFileBase(a.article)) === wanted)
+  )
+}

--- a/frontend/src/views/ArchiveView.vue
+++ b/frontend/src/views/ArchiveView.vue
@@ -3,7 +3,8 @@ import { ref, onMounted, onBeforeUnmount, watch, computed, nextTick } from 'vue'
 import axios from 'axios'
 import { settings, setViewMode as saveGlobalViewMode } from '../store/settings'
 import ArticleProgressLabel from '../components/ArticleProgressLabel.vue'
-import { isMoc } from '../utils/moc'
+import MocProgressLabel from '../components/MocProgressLabel.vue'
+import { isMoc, type MocProgress } from '../utils/moc'
 
 interface Article {
   ID: number
@@ -16,6 +17,7 @@ interface Article {
   reading_progress?: number
   reading_time?: string
   word_count?: number
+  moc_progress?: MocProgress | null
 }
 
 const articles = ref<Article[]>([])
@@ -144,6 +146,12 @@ function getReadingTime(articleOrText?: Article | string | null): string {
 function isMocArticle(article: Article): boolean {
   if (!article) return false
   return isMoc(article.title, article.parsedTags)
+}
+
+// A hub with no resolvable members shows no indicator at all, so the pill that
+// floats over a cover image must collapse with it rather than sit there empty.
+function hasReadingIndicator(article: Article): boolean {
+  return !isMocArticle(article) || !!article.moc_progress
 }
 
 function getDomain(article: Article): string {
@@ -412,10 +420,16 @@ const secondaryArticles = computed(() => {
                   <span>{{ formatDate(leadArticle.ID) || 'Recent' }}</span>
                   <span>•</span>
                   <span>{{ getReadingTime(leadArticle) }}</span>
-                  <span>•</span>
-                  <ArticleProgressLabel
+                  <span v-if="hasReadingIndicator(leadArticle)">•</span>
+                  <MocProgressLabel
+                    v-if="isMocArticle(leadArticle)"
                     variant="meta"
-                    :status="isMocArticle(leadArticle) ? 'not_started' : leadArticle.reading_status"
+                    :progress="leadArticle.moc_progress"
+                  />
+                  <ArticleProgressLabel
+                    v-else
+                    variant="meta"
+                    :status="leadArticle.reading_status"
                     :progress="leadArticle.reading_progress"
                   />
                 </div>
@@ -542,9 +556,15 @@ const secondaryArticles = computed(() => {
                   <span class="w-1 h-1 rounded-full bg-amber-400"></span>
                   {{ getDomain(article) }}
                 </span>
-                <ArticleProgressLabel
+                <MocProgressLabel
+                  v-if="isMocArticle(article)"
                   variant="overlay"
-                  :status="isMocArticle(article) ? 'not_started' : article.reading_status"
+                  :progress="article.moc_progress"
+                />
+                <ArticleProgressLabel
+                  v-else
+                  variant="overlay"
+                  :status="article.reading_status"
                   :progress="article.reading_progress"
                 />
               </div>
@@ -561,10 +581,16 @@ const secondaryArticles = computed(() => {
                 <span class="w-1 h-1 rounded-full bg-amber-400"></span>
                 {{ getDomain(article) }}
               </span>
-              <span class="px-2.5 py-0.5 rounded-full bg-black/60 backdrop-blur-md border border-white/15 shadow-xs inline-flex items-center">
-                <ArticleProgressLabel
+              <span v-if="hasReadingIndicator(article)" class="px-2.5 py-0.5 rounded-full bg-black/60 backdrop-blur-md border border-white/15 shadow-xs inline-flex items-center">
+                <MocProgressLabel
+                  v-if="isMocArticle(article)"
                   variant="overlay"
-                  :status="isMocArticle(article) ? 'not_started' : article.reading_status"
+                  :progress="article.moc_progress"
+                />
+                <ArticleProgressLabel
+                  v-else
+                  variant="overlay"
+                  :status="article.reading_status"
                   :progress="article.reading_progress"
                 />
               </span>
@@ -718,9 +744,15 @@ const secondaryArticles = computed(() => {
                   {{ getReadingTime(article) }}
                 </span>
 
-                <ArticleProgressLabel
+                <MocProgressLabel
+                  v-if="isMocArticle(article)"
                   variant="meta"
-                  :status="isMocArticle(article) ? 'not_started' : article.reading_status"
+                  :progress="article.moc_progress"
+                />
+                <ArticleProgressLabel
+                  v-else
+                  variant="meta"
+                  :status="article.reading_status"
                   :progress="article.reading_progress"
                 />
 


### PR DESCRIPTION
MOC cards showed **"New!"** forever. That was hard-coded, not a data bug: all eight call sites passed `status="not_started"` for a hub, because a hub never accumulates reading progress. The result was a badge that lied — a hub whose entire collection you had read still said New.

A MOC is a collection, so the progress that means something is **how much of the collection is read**. Hubs now show a segmented ring over `4/10 notes`.

Along the way this also fixes three dead wikilinks in the Azure MOC, which turned out to share a root cause worth its own commit.

## Commits

| | |
|---|---|
| `26e4eb5` | Backend: derive the rollup from `article_links` |
| `10dbf00` | Frontend: indicator components + the eight card call sites |
| `efe3eab` | Reader: collection progress on MOC hub pages |
| `e782650` | Fix: follow wikilinks whose filename differs from the title |

## How it works

`GetMOCProgress` rolls up member reading state for every hub in **one query**, joining `article_links` to articles and their statuses, so a list response costs one extra round trip rather than one per hub. Members come from `article_links` rows — the same records `librarian.go` and `organizer.go` already treat as membership.

Two invariants the rollup respects:

- Members are classified through **`DeriveStatusKey`**, not by comparing `progress` inline. That is the one place honouring a manual override and the 98% finished threshold; duplicating it here would let a hub disagree with the cards it indexes.
- Targets are **deduplicated**, because `article_links` has no unique constraint — the delete-then-recreate path in `librarian.go` and the count-guard in `transform.go` both avoid duplicates without the schema enforcing it.

The result rides on `GormArticle` as a non-persisted pointer. **Nothing new is stored**, and the existing guards that stop a hub ever writing an `article_statuses` row are untouched — a hub with no resolvable members stays nil so the key is omitted entirely and the UI renders no indicator.

## Design decisions

These came out of a design review of the first cut, and each looks arbitrary without its reason:

**No blue in the label.** On an article blue means "partway through this document", but a hub's number counts *finished* members, and the colour contradicted the ring on real data — a hub with one note read has a green-only ring, and 0 read / 1 in progress rendered as a saturated blue chip reading `0/10`. Blue stays in the ring, where it sits against green at proportional length. Neutral under 100%, emerald at completion.

**"4/10 notes", not "4/10 read".** The same meta row already carries `5 min read` a few characters away, and one row should not use one word for a duration and for a count of finished things.

**The ring is heavier than `ArticleStatusRing`** (r 8.25, stroke 3.5, 14px). That ring restates its one fraction in the number beside it, so it can afford to be a garnish; this one carries a quantity — notes in progress — that appears in no visible text. At the original 12px a tenth of a turn was under 3px of arc on a 1.25px stroke, and **two of three real hubs rendered as a bare track**.

Also: arcs are nested from a common origin rather than laid end to end (the untouched remainder is exposed track, no per-segment offset arithmetic); butt caps, since a round cap would overhang and let green bleed past its own count; track contrast raised off the 1.5:1 `gray-300` default, since the track encodes the unread remainder rather than decorating; the ★ MOC badge moved ahead of the indicator in list rows so the eye learns the card is a hub before reading a fraction; and no arc transition, because a hub's counts only change between page loads.

## The wikilink fix

Three links in the Azure MOC rendered as dead text — the three notes in the vault whose **filename is not their title**, because `SanitizeTitleFilename` has to produce a legal cross-platform name (it replaces `? : * " < > | # ^ [ ]` with spaces and truncates at 100 characters):

```
What is Azure Pipelines? - Azure Pipelines
  -> What is Azure Pipelines - Azure Pipelines.md
```

A wikilink names a file, not a title, so the Librarian correctly emits `[[<file base>|<real title>]]` for exactly these. The reader could not follow them.

Resolution tried title, then id, then path. Title fails by definition here. **The path fallback — the one that existed to catch this case — was broken for every note in a topic folder**: it stripped only `/articles/`, leaving `Microsoft Azure/What is Azure Pipelines - Azure Pipelines`, and compared that against a bare filename. It could never match. These three notes were simply the first to need it.

Resolution now lives in one tested helper that also matches the bare filename, replacing three hand-rolled copies of the ladder so it cannot drift again. Filename is tried **last** on purpose: two topic folders may hold files of the same name, so exact title, id and path matches win first.

## Verification

- `go vet`, `go test -race ./...`, `bun test` (48), `bun run build` — all green. `golangci-lint` was not run; it is not installed locally.
- Backend rollup exercised against a copy of the real vault through the actual `ListArticles` path: Kubernetes `1/0/10`, Azure `0/1/10`, Rise Against `4/3/10`. No non-MOC carries the key; no `null` `moc_progress` is emitted.
- Wikilinks checked against the vault: the old logic left **3 of 10** Azure links dead, the new logic resolves **10 of 10**, with Kubernetes and Rise Against unchanged at 10/10. No filenames currently collide across folders.
- Every visual state was checked in-browser at true rendered size, in both themes, across all four card layouts plus the overlay and reader variants.

## Follow-ups, not in this PR

- Wikilink resolution should move into the vault module; `GET /articles/*` has the same latent bug, masked today only because the frontend resolves to an ID before fetching. Issue to follow.
- `getReadingTime()` still renders `5 min read` on MOC cards — a duration for a generated index, the same class of bug as the progress one, in the same row.
- A hub with **no** members is indistinguishable from an API that did not send the field, so it renders nothing. An explicit empty-hub state would need the backend to send `{total: 0}`; a hub indexing nothing means the Librarian misfired, which is worth surfacing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reading-progress indicators for Map of Content hubs across home, archive, and reader views.
  - Progress displays show total items, completed items, and items in progress.
  - Improved wikilink resolution across titles, paths, filenames, and numeric IDs.

- **Bug Fixes**
  - MOC hubs without members no longer display misleading reading indicators.
  - Wikilink matching now handles normalization and ambiguous title/filename matches more reliably.

- **Tests**
  - Added coverage for MOC progress calculations, progress rendering behavior, and wikilink resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->